### PR TITLE
Support cross compile with `--target-dir` and `--target`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ getopts = "0.2"
 thiserror = "1"
 elf = "0.0.10"
 
+[dev-dependencies]
+tempfile = "3"
+
 [package.metadata.generate-rpm]
 assets = [
     { source = "target/release/cargo-generate-rpm", dest = "/usr/bin/cargo-generate-rpm", mode = "0755" },

--- a/README.md
+++ b/README.md
@@ -114,3 +114,23 @@ If both not found, `cargo generate-rpm` shall fail with an error.
 
 For example, `source = target/bin/XXX` would usually be treated as a relative path from the current directory. 
 Because all packages in the workspace share a common output directory that is located `target` in workspace directory.
+
+### Cross compilation
+
+This command supports `--target-dir` and `--target` option like `cargo build`.
+Depending on these options, this command changes the RPM package file location and replaces `target/release/` of
+the source locations of the assets.
+
+```sh
+cargo build --release --target x86_64-unknown-linux-gnu
+cargo generate-rpm --target x86_64-unknown-linux-gnu
+```
+
+When `--target-dir TARGET-DIR` and `--target x86_64-unknown-linux-gnu` are specified, a binary RPM file will be created
+at `TARGET-DIR/x86_64-unknown-linux-gnu/generate-rpm/XXX.rpm` instead of `target/generate-rpm/XXX.rpm`.
+In this case, the source of the asset `{ source = "target/release/XXX", dest = "/usr/bin/XXX" }` will be treated as
+`TARGET-DIR/x86_64-unknown-linux-gnu/release/XXX` instead of `target/releaseXXX`.
+
+You can use `CARGO_BUILD_TARGET` environment variable instead of `--target-dir` option and `CARGO_BUILD_TARGET_DIR` or
+`CARGO_TARGET_DIR` instead of `--target`.
+

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ cargo generate-rpm --target x86_64-unknown-linux-gnu
 When `--target-dir TARGET-DIR` and `--target x86_64-unknown-linux-gnu` are specified, a binary RPM file will be created
 at `TARGET-DIR/x86_64-unknown-linux-gnu/generate-rpm/XXX.rpm` instead of `target/generate-rpm/XXX.rpm`.
 In this case, the source of the asset `{ source = "target/release/XXX", dest = "/usr/bin/XXX" }` will be treated as
-`TARGET-DIR/x86_64-unknown-linux-gnu/release/XXX` instead of `target/releaseXXX`.
+`TARGET-DIR/x86_64-unknown-linux-gnu/release/XXX` instead of `target/release/XXX`.
 
-You can use `CARGO_BUILD_TARGET` environment variable instead of `--target-dir` option and `CARGO_BUILD_TARGET_DIR` or
-`CARGO_TARGET_DIR` instead of `--target`.
+You can use `CARGO_BUILD_TARGET` environment variable instead of `--target` option and `CARGO_BUILD_TARGET_DIR` or
+`CARGO_TARGET_DIR` instead of `--target-dir`.
 

--- a/src/auto_req/builtin.rs
+++ b/src/auto_req/builtin.rs
@@ -58,7 +58,7 @@ fn find_requires_by_ldd(
                 || so_name.starts_with("ld64.")
                 || so_name.starts_with("ld64-")
                 || so_name.starts_with("lib"))
-    };
+    }
 
     let process = Command::new("ldd")
         .arg("-v")

--- a/src/build_target.rs
+++ b/src/build_target.rs
@@ -1,0 +1,108 @@
+use std::env::consts::ARCH;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default)]
+pub struct BuildTarget {
+    pub target_dir: Option<String>,
+    pub target: Option<String>,
+    pub arch: Option<String>,
+}
+
+impl BuildTarget {
+    pub fn build_target_path(&self) -> PathBuf {
+        if let Some(target_dir) = &self.target_dir {
+            PathBuf::from(&target_dir)
+        } else {
+            let target_build_dir = std::env::var("CARGO_BUILD_TARGET_DIR")
+                .or_else(|_| std::env::var("CARGO_TARGET_DIR"))
+                .unwrap_or("target".to_string());
+            PathBuf::from(&target_build_dir)
+        }
+    }
+
+    pub fn target_path<P: AsRef<Path>>(&self, dir_name: P) -> PathBuf {
+        let mut path = self.build_target_path();
+        if let Some(target) = &self.target {
+            path = path.join(target)
+        }
+        path.join(dir_name)
+    }
+
+    pub fn binary_arch(&self) -> String {
+        if let Some(arch) = &self.arch {
+            arch.clone()
+        } else {
+            let arch = self
+                .target
+                .as_ref()
+                .and_then(|v| v.splitn(2, "-").nth(0))
+                .unwrap_or_else(|| ARCH);
+
+            match arch {
+                "x86" => "i586",
+                "arm" => "armhfp",
+                "powerpc" => "ppc",
+                "powerpc64" => "ppc64",
+                _ => arch,
+            }
+            .to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_build_target_path() {
+        let target = BuildTarget::default();
+        assert_eq!(target.build_target_path(), PathBuf::from("target"));
+
+        let target = BuildTarget {
+            target_dir: Some("/tmp/foobar/target".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            target.build_target_path(),
+            PathBuf::from("/tmp/foobar/target")
+        );
+    }
+
+    #[test]
+    fn test_target_path() {
+        let target = BuildTarget::default();
+        assert_eq!(
+            target.target_path("release"),
+            PathBuf::from("target/release")
+        );
+
+        let target = BuildTarget {
+            target: Some("x86_64-unknown-linux-gnu".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            target.target_path("release"),
+            PathBuf::from("target/x86_64-unknown-linux-gnu/release")
+        );
+
+        let target = BuildTarget {
+            target_dir: Some("/tmp/foobar/target".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            target.target_path("debug"),
+            PathBuf::from("/tmp/foobar/target/debug")
+        );
+
+        let target = BuildTarget {
+            target_dir: Some("/tmp/foobar/target".to_string()),
+            target: Some("x86_64-unknown-linux-gnu".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            target.target_path("debug"),
+            PathBuf::from("/tmp/foobar/target/x86_64-unknown-linux-gnu/debug")
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ impl Config {
                     None
                 } as Option<&str>
             }
-        };
+        }
         macro_rules! get_i64_from_metadata {
             ($name:expr) => {
                 if let Some(val) = metadata.get($name) {
@@ -109,7 +109,7 @@ impl Config {
                     None
                 } as Option<i64>
             }
-        };
+        }
         macro_rules! get_table_from_metadata {
             ($name:expr) => {
                 if let Some(val) = metadata.get($name) {
@@ -122,7 +122,7 @@ impl Config {
                     None
                 } as Option<&Table>
             }
-        };
+        }
 
         let pkg = self
             .manifest

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,15 @@
-use crate::auto_req::{find_requires, AutoReqMode};
-use crate::error::{ConfigError, Error};
-use cargo_toml::Error as CargoTomlError;
-use cargo_toml::Manifest;
-use rpm::{Compressor, Dependency, RPMBuilder, RPMFileOptions};
 use std::env::consts::ARCH;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+
+use cargo_toml::Error as CargoTomlError;
+use cargo_toml::Manifest;
+use rpm::{Compressor, Dependency, RPMBuilder};
 use toml::value::Table;
+
+use crate::auto_req::{find_requires, AutoReqMode};
+use crate::error::{ConfigError, Error};
+use crate::file_info::FileInfo;
 
 #[derive(Debug)]
 pub struct Config {
@@ -28,7 +31,7 @@ impl Config {
             })
     }
 
-    fn metadata(&self) -> Result<&Table, ConfigError> {
+    pub(crate) fn metadata(&self) -> Result<&Table, ConfigError> {
         let pkg = self
             .manifest
             .package
@@ -145,21 +148,13 @@ impl Config {
             .or_else(|| pkg.description.as_ref().map(|v| v.as_ref()))
             .ok_or(ConfigError::Missing("package.description"))?;
         let files = FileInfo::list_from_metadata(&metadata)?;
+        let parent = self.path.parent().unwrap();
 
         let mut builder = RPMBuilder::new(name, version, license, arch.as_str(), desc)
             .compression(Compressor::from_str("gzip").unwrap());
         for file in &files {
+            let file_source = file.generate_rpm_file_path(parent)?;
             let options = file.generate_rpm_file_options();
-
-            let file_source = [
-                PathBuf::from(file.source),
-                self.path.parent().unwrap().join(file.source),
-            ]
-            .iter()
-            .find(|v| v.exists())
-            .ok_or_else(|| ConfigError::AssetFileNotFound(file.source.to_string()))?
-            .to_owned();
-
             builder = builder.with_file(file_source, options)?;
         }
 
@@ -220,131 +215,11 @@ impl Config {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct FileInfo<'a, 'b, 'c, 'd> {
-    source: &'a str,
-    dest: &'b str,
-    user: Option<&'c str>,
-    group: Option<&'d str>,
-    mode: Option<usize>,
-    config: bool,
-    doc: bool,
-}
-
-impl FileInfo<'_, '_, '_, '_> {
-    pub fn list_from_metadata(metadata: &Table) -> Result<Vec<FileInfo>, ConfigError> {
-        let assets = metadata
-            .get("assets")
-            .ok_or(ConfigError::Missing("package.metadata.generate-rpm.assets"))?
-            .as_array()
-            .ok_or(ConfigError::WrongType(
-                "package.metadata.generate-rpm.assets",
-                "array",
-            ))?;
-
-        let mut files = Vec::with_capacity(assets.len());
-        for (idx, value) in assets.iter().enumerate() {
-            let table = value
-                .as_table()
-                .ok_or(ConfigError::AssetFileUndefined(idx, "source"))?;
-            let source = table
-                .get("source")
-                .ok_or(ConfigError::AssetFileUndefined(idx, "source"))?
-                .as_str()
-                .ok_or(ConfigError::AssetFileWrongType(idx, "source", "string"))?;
-            let dest = table
-                .get("dest")
-                .ok_or(ConfigError::AssetFileUndefined(idx, "dest"))?
-                .as_str()
-                .ok_or(ConfigError::AssetFileWrongType(idx, "dest", "string"))?;
-
-            let user = if let Some(user) = table.get("user") {
-                Some(
-                    user.as_str()
-                        .ok_or(ConfigError::AssetFileWrongType(idx, "user", "string"))?,
-                )
-            } else {
-                None
-            };
-            let group = if let Some(group) = table.get("group") {
-                Some(
-                    group
-                        .as_str()
-                        .ok_or(ConfigError::AssetFileWrongType(idx, "group", "string"))?,
-                )
-            } else {
-                None
-            };
-            let mode = if let Some(mode) = table.get("mode") {
-                let mode = mode
-                    .as_str()
-                    .ok_or(ConfigError::AssetFileWrongType(idx, "mode", "string"))?;
-                let mode = usize::from_str_radix(mode, 8)
-                    .map_err(|_| ConfigError::AssetFileWrongType(idx, "mode", "oct-string"))?;
-                let file_mode = if mode & 0o170000 != 0 {
-                    None
-                } else if source.ends_with('/') {
-                    Some(0o040000) // S_IFDIR
-                } else {
-                    Some(0o100000) // S_IFREG
-                };
-                Some(file_mode.unwrap_or_default() | mode)
-            } else {
-                None
-            };
-            let config = if let Some(is_config) = table.get("config") {
-                is_config
-                    .as_bool()
-                    .ok_or(ConfigError::AssetFileWrongType(idx, "config", "bool"))?
-            } else {
-                false
-            };
-            let doc = if let Some(is_doc) = table.get("doc") {
-                is_doc
-                    .as_bool()
-                    .ok_or(ConfigError::AssetFileWrongType(idx, "doc", "bool"))?
-            } else {
-                false
-            };
-
-            files.push(FileInfo {
-                source,
-                dest,
-                user,
-                group,
-                mode,
-                config,
-                doc,
-            });
-        }
-        Ok(files)
-    }
-
-    fn generate_rpm_file_options(&self) -> RPMFileOptions {
-        let mut rpm_file_option = RPMFileOptions::new(self.dest);
-        if let Some(user) = self.user {
-            rpm_file_option = rpm_file_option.user(user);
-        }
-        if let Some(group) = self.group {
-            rpm_file_option = rpm_file_option.group(group);
-        }
-        if let Some(mode) = self.mode {
-            rpm_file_option = rpm_file_option.mode(mode as i32);
-        }
-        if self.config {
-            rpm_file_option = rpm_file_option.is_config();
-        }
-        if self.doc {
-            rpm_file_option = rpm_file_option.is_doc();
-        }
-        rpm_file_option.into()
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::*;
     use cargo_toml::Value;
+
+    use super::*;
 
     #[test]
     fn test_config_new() {
@@ -445,46 +320,5 @@ mod test {
         } else {
             matches!(builder, Err(Error::Config(ConfigError::AssetFileNotFound(path))) if path == "target/release/cargo-generate-rpm")
         });
-    }
-
-
-
-    #[test]
-    fn test_files() {
-        let config = Config::new("Cargo.toml").unwrap();
-        let metadata = config.metadata().unwrap();
-        let files = FileInfo::list_from_metadata(&metadata).unwrap();
-        assert_eq!(
-            files,
-            vec![
-                FileInfo {
-                    source: "target/release/cargo-generate-rpm",
-                    dest: "/usr/bin/cargo-generate-rpm",
-                    user: None,
-                    group: None,
-                    mode: Some(0o0100755),
-                    config: false,
-                    doc: false
-                },
-                FileInfo {
-                    source: "LICENSE",
-                    dest: "/usr/share/doc/cargo-generate-rpm/LICENSE",
-                    user: None,
-                    group: None,
-                    mode: Some(0o0100644),
-                    config: false,
-                    doc: true
-                },
-                FileInfo {
-                    source: "README.md",
-                    dest: "/usr/share/doc/cargo-generate-rpm/README.md",
-                    user: None,
-                    group: None,
-                    mode: Some(0o0100644),
-                    config: false,
-                    doc: true
-                }
-            ]
-        );
     }
 }

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -1,0 +1,183 @@
+use rpm::RPMFileOptions;
+use toml::value::Table;
+
+use crate::error::ConfigError;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct FileInfo<'a, 'b, 'c, 'd> {
+    pub source: &'a str,
+    pub dest: &'b str,
+    pub user: Option<&'c str>,
+    pub group: Option<&'d str>,
+    pub mode: Option<usize>,
+    pub config: bool,
+    pub doc: bool,
+}
+
+impl FileInfo<'_, '_, '_, '_> {
+    pub fn list_from_metadata(metadata: &Table) -> Result<Vec<FileInfo>, ConfigError> {
+        let assets = metadata
+            .get("assets")
+            .ok_or(ConfigError::Missing("package.metadata.generate-rpm.assets"))?
+            .as_array()
+            .ok_or(ConfigError::WrongType(
+                "package.metadata.generate-rpm.assets",
+                "array",
+            ))?;
+
+        let mut files = Vec::with_capacity(assets.len());
+        for (idx, value) in assets.iter().enumerate() {
+            let table = value
+                .as_table()
+                .ok_or(ConfigError::AssetFileUndefined(idx, "source"))?;
+            let source = table
+                .get("source")
+                .ok_or(ConfigError::AssetFileUndefined(idx, "source"))?
+                .as_str()
+                .ok_or(ConfigError::AssetFileWrongType(idx, "source", "string"))?;
+            let dest = table
+                .get("dest")
+                .ok_or(ConfigError::AssetFileUndefined(idx, "dest"))?
+                .as_str()
+                .ok_or(ConfigError::AssetFileWrongType(idx, "dest", "string"))?;
+
+            let user = if let Some(user) = table.get("user") {
+                Some(
+                    user.as_str()
+                        .ok_or(ConfigError::AssetFileWrongType(idx, "user", "string"))?,
+                )
+            } else {
+                None
+            };
+            let group = if let Some(group) = table.get("group") {
+                Some(
+                    group
+                        .as_str()
+                        .ok_or(ConfigError::AssetFileWrongType(idx, "group", "string"))?,
+                )
+            } else {
+                None
+            };
+            let mode = Self::get_mode(&table, source, idx)?;
+            let config = if let Some(is_config) = table.get("config") {
+                is_config
+                    .as_bool()
+                    .ok_or(ConfigError::AssetFileWrongType(idx, "config", "bool"))?
+            } else {
+                false
+            };
+            let doc = if let Some(is_doc) = table.get("doc") {
+                is_doc
+                    .as_bool()
+                    .ok_or(ConfigError::AssetFileWrongType(idx, "doc", "bool"))?
+            } else {
+                false
+            };
+
+            files.push(FileInfo {
+                source,
+                dest,
+                user,
+                group,
+                mode,
+                config,
+                doc,
+            });
+        }
+        Ok(files)
+    }
+
+    fn get_mode(table: &Table, source: &str, idx: usize) -> Result<Option<usize>, ConfigError> {
+        if let Some(mode) = table.get("mode") {
+            let mode = mode
+                .as_str()
+                .ok_or(ConfigError::AssetFileWrongType(idx, "mode", "string"))?;
+            let mode = usize::from_str_radix(mode, 8)
+                .map_err(|_| ConfigError::AssetFileWrongType(idx, "mode", "oct-string"))?;
+            let file_mode = if mode & 0o170000 != 0 {
+                None
+            } else if source.ends_with('/') {
+                Some(0o040000) // S_IFDIR
+            } else {
+                Some(0o100000) // S_IFREG
+            };
+            Ok(Some(file_mode.unwrap_or_default() | mode))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn generate_rpm_file_path(&self, parent: &Path) -> Result<PathBuf, ConfigError> {
+        [Path::new(self.source), parent.join(self.source).as_path()]
+            .iter()
+            .find(|v| v.exists())
+            .map(|v| v.to_path_buf())
+            .ok_or_else(|| ConfigError::AssetFileNotFound(self.source.to_string()))
+    }
+
+    pub(crate) fn generate_rpm_file_options(&self) -> RPMFileOptions {
+        let mut rpm_file_option = RPMFileOptions::new(self.dest);
+        if let Some(user) = self.user {
+            rpm_file_option = rpm_file_option.user(user);
+        }
+        if let Some(group) = self.group {
+            rpm_file_option = rpm_file_option.group(group);
+        }
+        if let Some(mode) = self.mode {
+            rpm_file_option = rpm_file_option.mode(mode as i32);
+        }
+        if self.config {
+            rpm_file_option = rpm_file_option.is_config();
+        }
+        if self.doc {
+            rpm_file_option = rpm_file_option.is_doc();
+        }
+        rpm_file_option.into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::Config;
+
+    #[test]
+    fn test_files() {
+        let config = Config::new("Cargo.toml").unwrap();
+        let metadata = config.metadata().unwrap();
+        let files = FileInfo::list_from_metadata(&metadata).unwrap();
+        assert_eq!(
+            files,
+            vec![
+                FileInfo {
+                    source: "target/release/cargo-generate-rpm",
+                    dest: "/usr/bin/cargo-generate-rpm",
+                    user: None,
+                    group: None,
+                    mode: Some(0o0100755),
+                    config: false,
+                    doc: false
+                },
+                FileInfo {
+                    source: "LICENSE",
+                    dest: "/usr/share/doc/cargo-generate-rpm/LICENSE",
+                    user: None,
+                    group: None,
+                    mode: Some(0o0100644),
+                    config: false,
+                    doc: true
+                },
+                FileInfo {
+                    source: "README.md",
+                    dest: "/usr/share/doc/cargo-generate-rpm/README.md",
+                    user: None,
+                    group: None,
+                    mode: Some(0o0100644),
+                    config: false,
+                    doc: true
+                }
+            ]
+        );
+    }
+}

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -109,11 +109,14 @@ impl FileInfo<'_, '_, '_, '_> {
     }
 
     pub(crate) fn generate_rpm_file_path(&self, parent: &Path) -> Result<PathBuf, ConfigError> {
-        [Path::new(self.source), parent.join(self.source).as_path()]
-            .iter()
-            .find(|v| v.exists())
-            .map(|v| v.to_path_buf())
-            .ok_or_else(|| ConfigError::AssetFileNotFound(self.source.to_string()))
+        let source = FileLocationReplacementRule::default().apply(self.source);
+        if source.exists() {
+            Ok(source)
+        } else if parent.join(source.clone()).exists() {
+            Ok(parent.join(source))
+        } else {
+            Err(ConfigError::AssetFileNotFound(self.source.to_string()))
+        }
     }
 
     pub(crate) fn generate_rpm_file_options(&self) -> RPMFileOptions {
@@ -137,13 +140,47 @@ impl FileInfo<'_, '_, '_, '_> {
     }
 }
 
+struct FileLocationReplacementRule {
+    target_dir: Option<String>,
+    target: Option<String>,
+}
+
+impl FileLocationReplacementRule {
+    fn apply<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        if let Ok(rel_path) = path.as_ref().strip_prefix("target/release") {
+            let target_dir =
+                PathBuf::from(self.target_dir.as_ref().unwrap_or(&"target".to_string()));
+            if let Some(target) = &self.target {
+                target_dir.join(target).join("release").join(rel_path)
+            } else {
+                target_dir.join("release".to_string()).join(rel_path)
+            }
+        } else {
+            path.as_ref().to_path_buf()
+        }
+    }
+}
+
+impl Default for FileLocationReplacementRule {
+    fn default() -> Self {
+        let target_build_dir = std::env::var("CARGO_BUILD_TARGET_DIR")
+            .or_else(|_| std::env::var("CARGO_TARGET_DIR"))
+            .ok();
+        let target = std::env::var("CARGO_BUILD_TARGET").ok();
+        Self {
+            target_dir: target_build_dir,
+            target,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::config::Config;
 
     #[test]
-    fn test_files() {
+    fn test_list_from_metadata() {
         let config = Config::new("Cargo.toml").unwrap();
         let metadata = config.metadata().unwrap();
         let files = FileInfo::list_from_metadata(&metadata).unwrap();
@@ -178,6 +215,45 @@ mod test {
                     doc: true
                 }
             ]
+        );
+    }
+
+    #[test]
+    fn test_file_location_replacement_rule() {
+        let rule = FileLocationReplacementRule {
+            target_dir: None,
+            target: None,
+        };
+        assert_eq!(
+            rule.apply("target/release/foobar"),
+            PathBuf::from("target/release/foobar")
+        );
+
+        let rule = FileLocationReplacementRule {
+            target_dir: Some("TARGET_DIR".to_string()),
+            target: None,
+        };
+        assert_eq!(
+            rule.apply("target/release/foobar"),
+            PathBuf::from("TARGET_DIR/release/foobar")
+        );
+
+        let rule = FileLocationReplacementRule {
+            target_dir: None,
+            target: Some("TARGET".to_string()),
+        };
+        assert_eq!(
+            rule.apply("target/release/foobar"),
+            PathBuf::from("target/TARGET/release/foobar")
+        );
+
+        let rule = FileLocationReplacementRule {
+            target_dir: Some("TARGET_DIR".to_string()),
+            target: Some("TARGET".to_string()),
+        };
+        assert_eq!(
+            rule.apply("target/release/foobar"),
+            PathBuf::from("TARGET_DIR/TARGET/release/foobar")
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 mod auto_req;
 mod config;
 mod error;
+mod file_info;
 
 fn process(
     target_arch: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,6 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqM
     let mut opts = Options::new();
     opts.optopt("a", "arch", "set target arch", "ARCH");
     opts.optopt("o", "output", "set output file", "OUTPUT.rpm");
-    opts.optflag("h", "help", "print this help menu");
     opts.optopt(
         "p",
         "package",
@@ -95,6 +94,8 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqM
         "DIRECTORY",
     );
 
+    opts.optflag("h", "help", "print this help menu");
+
     let opt_matches = opts.parse(env::args().skip(1)).unwrap_or_else(|err| {
         eprintln!("{}: {}", program, err);
         std::process::exit(1);
@@ -103,6 +104,7 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqM
         println!("{}", opts.usage(&*format!("Usage: {} [options]", program)));
         std::process::exit(0);
     }
+
     if let Some(target_arch) = opt_matches.opt_str("a") {
         build_target.arch = Some(target_arch);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,21 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqM
          auto(Default), no, builtin, /path/to/find-requires",
         "MODE",
     );
+    opts.optopt(
+        "",
+        "target",
+        "Sub-directory name for all generated artifacts. \
+    May be specified with CARGO_BUILD_TARGET environment variable.",
+        "TARGET-TRIPLE",
+    );
+    opts.optopt(
+        "",
+        "target-dir",
+        "Directory for all generated artifacts. \
+    May be specified with CARGO_BUILD_TARGET_DIR or CARGO_TARGET_DIR environment variables.",
+        "DIRECTORY",
+    );
+
     let opt_matches = opts.parse(env::args().skip(1)).unwrap_or_else(|err| {
         eprintln!("{}: {}", program, err);
         std::process::exit(1);
@@ -98,6 +113,12 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqM
             .opt_str("auto-req")
             .unwrap_or("auto".to_string()),
     )?;
+    if let Some(target) = opt_matches.opt_str("target") {
+        build_target.target = Some(target);
+    }
+    if let Some(target_dir) = opt_matches.opt_str("target-dir") {
+        build_target.target_dir = Some(target_dir);
+    }
 
     Ok((build_target, target_file, package, auto_req_mode))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,21 @@
 use crate::auto_req::AutoReqMode;
+use crate::build_target::BuildTarget;
 use crate::config::Config;
 use crate::error::Error;
 use getopts::Options;
 use std::convert::TryFrom;
 use std::env;
 use std::fs::{create_dir_all, File};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 mod auto_req;
+mod build_target;
 mod config;
 mod error;
 mod file_info;
 
 fn process(
-    target_arch: Option<String>,
+    build_target: &BuildTarget,
     target_file: Option<PathBuf>,
     package: Option<String>,
     auto_req_mode: AutoReqMode,
@@ -23,10 +25,10 @@ fn process(
     let config = Config::new(manifest_file_path)?;
 
     let rpm_pkg = config
-        .create_rpm_builder(target_arch, auto_req_mode)?
+        .create_rpm_builder(build_target, auto_req_mode)?
         .build()?;
 
-    let default_file_name = Path::new("target").join("generate-rpm").join(format!(
+    let default_file_name = build_target.target_path("generate-rpm").join(format!(
         "{}-{}{}{}.rpm",
         rpm_pkg.metadata.header.get_name()?,
         rpm_pkg.metadata.header.get_version()?,
@@ -57,8 +59,9 @@ fn process(
     Ok(())
 }
 
-fn parse_arg() -> Result<(Option<String>, Option<PathBuf>, Option<String>, AutoReqMode), Error> {
+fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, AutoReqMode), Error> {
     let program = env::args().nth(0).unwrap();
+    let mut build_target = BuildTarget::default();
 
     let mut opts = Options::new();
     opts.optopt("a", "arch", "set target arch", "ARCH");
@@ -85,7 +88,9 @@ fn parse_arg() -> Result<(Option<String>, Option<PathBuf>, Option<String>, AutoR
         println!("{}", opts.usage(&*format!("Usage: {} [options]", program)));
         std::process::exit(0);
     }
-    let target_arch = opt_matches.opt_str("a");
+    if let Some(target_arch) = opt_matches.opt_str("a") {
+        build_target.arch = Some(target_arch);
+    }
     let target_file = opt_matches.opt_str("o").map(PathBuf::from);
     let package = opt_matches.opt_str("p");
     let auto_req_mode = AutoReqMode::try_from(
@@ -94,13 +99,13 @@ fn parse_arg() -> Result<(Option<String>, Option<PathBuf>, Option<String>, AutoR
             .unwrap_or("auto".to_string()),
     )?;
 
-    Ok((target_arch, target_file, package, auto_req_mode))
+    Ok((build_target, target_file, package, auto_req_mode))
 }
 
 fn main() {
     (|| -> Result<(), Error> {
-        let (target_arch, target_file, package, auto_req_mode) = parse_arg()?;
-        process(target_arch, target_file, package, auto_req_mode)?;
+        let (build_target, target_file, package, auto_req_mode) = parse_arg()?;
+        process(&build_target, target_file, package, auto_req_mode)?;
         Ok(())
     })()
     .unwrap_or_else(|err| {


### PR DESCRIPTION
Using cargo build with cross-compilation, the built binary files are placed in `target/<target-triple>/release`, not usual `target/release`.  The location of the asset source should be automatically corrected in this case. The RPM files should also follow this rule.

In addition, `--target-dir` should be support to change the `target` folder path.

close #13 