### PR TITLE
Fix build fail on rust 1.53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 rpm-rs = { git = "https://github.com/Richterrettich/rpm-rs.git", rev = "2dac707469cdc3a6c7032abd98d13bf494e00665" }
 toml = "0.5"
-cargo_toml = "0.8"
+cargo_toml = "0.9"
 getopts = "0.2"
 thiserror = "1"
 elf = "0.0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rpm-rs = "0.6"
+rpm-rs = { git = "https://github.com/Richterrettich/rpm-rs.git", rev = "2dac707469cdc3a6c7032abd98d13bf494e00665" }
 toml = "0.5"
 cargo_toml = "0.8"
 getopts = "0.2"


### PR DESCRIPTION
The latest revision of rpm-rs fixes this problem. But it is not pushed to crate.io. So git revision is specified in Cargo.toml.

In addition, update cargo_toml

to fix #21