### PR TITLE
Add glob capability to assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rpm-rs = "0.7"
+glob = "0.3.0"
+rpm-rs = "0.8.1"
 toml = "0.5"
 cargo_toml = "0.9"
 getopts = "0.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,7 +216,7 @@ impl Config {
         } else {
             rpm_builder_config.auto_req_mode
         };
-        for requires in find_requires(files.iter().map(|v| Path::new(v.source)), auto_req)? {
+        for requires in find_requires(files.iter().map(|v| Path::new(&v.source)), auto_req)? {
             builder = builder.requires(Dependency::any(requires));
         }
         if let Some(obsoletes) = get_table_from_metadata!("obsoletes") {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,12 @@ pub enum ConfigError {
     Missing(&'static str),
     #[error("Field {0} must be {1}")]
     WrongType(&'static str, &'static str),
+    #[error("Invalid Glob at {0}: {1}")]
+    AssetGlobInvalid(usize, &'static str),
+    #[error("Glob at {0}-th asset found {1} which doesn't appear to be in {2}")]
+    AssetGlobPathInvalid(usize, String, String),
+    #[error("Failed reading {0}-th asset")]
+    AssetReadFailed(usize),
     #[error("{1} of {0}-th asset is undefined")]
     AssetFileUndefined(usize, &'static str),
     #[error("{1} of {0}-th asset must be {2}")]

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -182,7 +182,7 @@ impl FileInfo<'_, '_> {
     }
 }
 
-fn _get_base_from_glob<'a>(idx: usize, glob: &'a str) -> Result<PathBuf, ConfigError> {
+fn _get_base_from_glob(idx: usize, glob: &'_ str) -> Result<PathBuf, ConfigError> {
     let base = if let Some(b) = glob.split('*').next() {
         b
     } else {


### PR DESCRIPTION
- Update rpm crate's version
- Add glob crate
- Add errors specific to globs
- Add glob detection and handling for assets

Glob support was already in cargo-deb and I wanted to have it in this crate, too. I added it for my own build, but I thought I'd share upstream. Please let me know if you'd like any changes at all. I could even feature gate it if you'd rather.

Thank you for the great crate, once again!