### PR TITLE
Support specifying release via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This command obtains RPM metadata from [the `Cargo.toml` file](https://doc.rust-
   * mode: the permissions as octal string. (e.g. `755` to indicate `-rwxr-xr-x`)
   * config: set true if it is a configuration file.
   * doc: set true if it is a document file.
-* release: optional string of release.
+* release: optional string of release. Ignored if `--release` is specified via CLI.
 * epoch: optional number of epoch.
 * pre_install_script: optional string of pre_install_script.
 * pre_uninstall_script: optional string of pre_uninstall_script.

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct RpmBuilderConfig<'a, 'b> {
     build_target: &'a BuildTarget,
     auto_req_mode: AutoReqMode,
     payload_compress: &'b str,
+    release: Option<&'b str>,
 }
 
 impl<'a, 'b> RpmBuilderConfig<'a, 'b> {
@@ -23,11 +24,13 @@ impl<'a, 'b> RpmBuilderConfig<'a, 'b> {
         build_target: &'a BuildTarget,
         auto_req_mode: AutoReqMode,
         payload_compress: &'b str,
+        release: Option<&'b str>,
     ) -> RpmBuilderConfig<'a, 'b> {
         RpmBuilderConfig {
             build_target,
             auto_req_mode,
             payload_compress,
+            release,
         }
     }
 }
@@ -182,7 +185,9 @@ impl Config {
             builder = builder.with_file(file_source, options)?;
         }
 
-        if let Some(release) = get_str_or_i64_from_metadata!("release") {
+        if let Some(release) = rpm_builder_config.release {
+            builder = builder.release(release);
+        } else if let Some(release) = get_str_or_i64_from_metadata!("release") {
             builder = builder.release(release);
         }
         if let Some(epoch) = get_i64_from_metadata!("epoch") {
@@ -341,6 +346,7 @@ mod test {
             &BuildTarget::default(),
             AutoReqMode::Disabled,
             "zstd",
+            None,
         ));
 
         assert!(if Path::new("target/release/cargo-generate-rpm").exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod file_info;
 struct CliSetting {
     auto_req_mode: AutoReqMode,
     payload_compress: String,
+    release: Option<String>,
 }
 
 fn process(
@@ -35,6 +36,7 @@ fn process(
             build_target,
             setting.auto_req_mode,
             setting.payload_compress.as_str(),
+            setting.release.as_deref(),
         ))?
         .build()?;
 
@@ -121,6 +123,13 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
         none, gzip or zstd(Default).",
         "TYPE",
     );
+    opts.optopt(
+        "",
+        "release",
+        "set a release string for the RPM. \
+        Overrides any value specified in Cargo.toml",
+        "RELEASE",
+    );
 
     opts.optflag("h", "help", "print this help menu");
 
@@ -153,6 +162,8 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
         .opt_str("payload-compress")
         .unwrap_or("zstd".to_string());
 
+    let release = opt_matches.opt_str("release");
+
     Ok((
         build_target,
         target_path,
@@ -160,6 +171,7 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
         CliSetting {
             auto_req_mode,
             payload_compress,
+            release,
         },
     ))
 }


### PR DESCRIPTION
I'd like to support specifying the release version string via CLI, because I want to build the same project for multiple different distributions, and include a distribution tag in the release, e.g `1.el7` or `2.fc35`.

But I want my Cargo.toml to remain distro-agnostic - I currently have to edit Cargo.toml and revert before each build to achieve this.