### PR TITLE
Support for rpm file which does not have a dependency on /bin/sh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm-rs = "0.8.1"
+rpm-rs = { package = "rpm", version = "0.9.0-alpha.1" }
 toml = "0.5"
 cargo_toml = "0.13"
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm-rs = { package = "rpm", version = "0.9.0-alpha.1" }
+rpm = "0.9.0-alpha.1"
 toml = "0.5"
-cargo_toml = "0.13"
+cargo_toml = "0.14"
 getopts = "0.2"
 thiserror = "1"
 elf = "0.0.10"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This command generates RPM metadata from [the `Cargo.toml` file](https://doc.rus
 * post_uninstall_script: optional string of post_uninstall_script.
 * requires: optional list of Requires
 * auto-req: optional string `"no"` to disable the automatic dependency process
+* require-sh: optional boolean `false` to omit `/bin/sh` from Requirements
 * obsoletes: optional list of Obsoletes
 * conflicts: optional list of Conflicts
 * provides: optional list of Provides
@@ -105,6 +106,9 @@ the user who executes this command may specify command line option `--auto-req n
  * `--auto-req builtin`: the builtin procedure using `ldd` is used.
  * `--auto-req /path/to/find-requires`: the specified external program is used. This behavior is the same as the original `rpmbuild`. 
  * `--auto-req no`: the process is disabled.
+
+`/bin/sh` is always added to the package requirements. To disable it, set `package.metadata.generate-rpm.require-sh` to `false`.
+You should not do this if you use scripts such as `pre_install_script` or if your assets contain shell scripts.
 
 ### Overwrite configuration
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -194,6 +194,8 @@ impl Config {
             builder = builder.post_uninstall_script(post_uninstall_script);
         }
 
+        builder = builder.requires(Dependency::any("/bin/sh".to_string()));
+
         if let Some(requires) = metadata.get_table("requires")? {
             for dependency in Self::table_to_dependencies(requires)? {
                 builder = builder.requires(dependency);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,8 +75,10 @@ impl Config {
                     }
                     _ => Error::CargoToml(err),
                 })?;
-            manifest.complete_from_path_and_workspace(manifest_path.as_path(), 
-            Some((&workspace_manifest, p)))?;
+            manifest.complete_from_path_and_workspace(
+                manifest_path.as_path(),
+                Some((&workspace_manifest, p)),
+            )?;
             manifest
         } else {
             Manifest::from_path(&manifest_path).map_err(|err| match err {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -194,7 +194,9 @@ impl Config {
             builder = builder.post_uninstall_script(post_uninstall_script);
         }
 
-        builder = builder.requires(Dependency::any("/bin/sh".to_string()));
+        if metadata.get_bool("require-sh")?.unwrap_or(true) {
+            builder = builder.requires(Dependency::any("/bin/sh".to_string()));
+        }
 
         if let Some(requires) = metadata.get_table("requires")? {
             for dependency in Self::table_to_dependencies(requires)? {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,8 +75,8 @@ impl Config {
                     }
                     _ => Error::CargoToml(err),
                 })?;
-            manifest.inherit_workspace(&workspace_manifest, p.as_ref())?;
-            manifest.complete_from_path(manifest_path.as_path())?;
+            manifest.complete_from_path_and_workspace(manifest_path.as_path(), 
+            Some((&workspace_manifest, p)))?;
             manifest
         } else {
             Manifest::from_path(&manifest_path).map_err(|err| match err {
@@ -176,7 +176,7 @@ impl Config {
             builder = builder.release(release);
         }
         if let Some(epoch) = metadata.get_i64("epoch")? {
-            builder = builder.epoch(epoch as i32);
+            builder = builder.epoch(epoch as u32);
         }
 
         if let Some(pre_install_script) = metadata.get_str("pre_install_script")? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,15 @@ fn process(
 
     let default_file_name = build_target.target_path("generate-rpm").join(format!(
         "{}-{}{}{}.rpm",
-        rpm_pkg.metadata.header.get_name()?,
-        rpm_pkg.metadata.header.get_version()?,
+        rpm_pkg.metadata.get_name()?,
+        rpm_pkg.metadata.get_version()?,
         rpm_pkg
             .metadata
-            .header
             .get_release()
             .map(|v| format!("-{}", v))
             .unwrap_or_default(),
         rpm_pkg
             .metadata
-            .header
             .get_arch()
             .map(|v| format!(".{}", v))
             .unwrap_or_default(),


### PR DESCRIPTION
`/bin/sh` is the package dependency which is not necessarily required if there is no (un)install script or script assets. This PR introduces a new configuration `package.metadata.generate-rpm.require-sh` to create packages not depending on `/bin/sh`.

to resolve #39