### PR TITLE
Add optional fields repository and vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ from [the `Cargo.toml` file](https://doc.rust-lang.org/cargo/reference/manifest.
 * version: the package version. If not present, `package.version` is used.
 * license: the package license. If not present, `package.license` is used.
 * summary: the package summary/description. If not present, `package.description` is used.
+* repository: the package repository url. If not present, `package.repository` is used.
 * assets: (**mandatory**) the array of the files to be included in the package
     * source: the location of that asset in the Rust project. (e.g. `target/release/XXX`)
       Wildcard character `*` is allowed.
@@ -63,6 +64,7 @@ from [the `Cargo.toml` file](https://doc.rust-lang.org/cargo/reference/manifest.
 * obsoletes: optional list of Obsoletes
 * conflicts: optional list of Conflicts
 * provides: optional list of Provides
+* vendor: optional string of Vendor
 
 Adding assets such as the binary file, ``.desktop`` file, or icons, shall be written in the following way.
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -195,6 +195,20 @@ impl Config {
             builder = builder.post_uninstall_script(post_uninstall_script);
         }
 
+        if let Some(repository) = match (metadata.get_str("repository")?, pkg.repository.as_ref()) {
+            (Some(v), _) => Some(v),
+            (None, None) => None,
+            (None, Some(v)) => Some(v.get()?.as_str()),
+        } {
+            // RPM uses the variable name `url` for the repository field.
+            // When querying the RPM with `rpm -qi`, the repository field is displayed `URL`
+            builder = builder.url(repository);
+        }
+
+        if let Some(vendor) = metadata.get_str("vendor")? {
+            builder = builder.vendor(vendor);
+        }
+
         if metadata.get_bool("require-sh")?.unwrap_or(true) {
             builder = builder.requires(Dependency::any("/bin/sh".to_string()));
         }


### PR DESCRIPTION
Tested locally to generate an rpm with vendor and repository both in `[package]` and `[package.metadata.generate-rpm]` in Cargo.toml