### PR TITLE
Rename package.metadata.generate-rpm.repository to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ from [the `Cargo.toml` file](https://doc.rust-lang.org/cargo/reference/manifest.
 * version: the package version. If not present, `package.version` is used.
 * license: the package license. If not present, `package.license` is used.
 * summary: the package summary/description. If not present, `package.description` is used.
-* repository: the package repository url. If not present, `package.repository` is used.
+* url: the package homepage url. If not present, `package.homepage` is used. If neither present, `package.repository` is
+  used.
 * assets: (**mandatory**) the array of the files to be included in the package
     * source: the location of that asset in the Rust project. (e.g. `target/release/XXX`)
       Wildcard character `*` is allowed.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -195,14 +195,17 @@ impl Config {
             builder = builder.post_uninstall_script(post_uninstall_script);
         }
 
-        if let Some(repository) = match (metadata.get_str("repository")?, pkg.repository.as_ref()) {
-            (Some(v), _) => Some(v),
-            (None, None) => None,
-            (None, Some(v)) => Some(v.get()?.as_str()),
+        if let Some(url) = match (
+            metadata.get_str("url")?,
+            pkg.homepage.as_ref(),
+            pkg.repository.as_ref(),
+        ) {
+            (Some(v), _, _) => Some(v),
+            (None, Some(v), _) => Some(v.get()?.as_str()),
+            (None, None, Some(v)) => Some(v.get()?.as_str()),
+            (None, None, None) => None,
         } {
-            // RPM uses the variable name `url` for the repository field.
-            // When querying the RPM with `rpm -qi`, the repository field is displayed `URL`
-            builder = builder.url(repository);
+            builder = builder.url(url);
         }
 
         if let Some(vendor) = metadata.get_str("vendor")? {


### PR DESCRIPTION
#54 introduced package.metadata.generate-rpm.repository to specify URL of the rpm file. But, "URL" is intended to store the URL of the package home page, not the repository URL. So, package.metadata.generate-rpm.repository should be renamed to package.metadata.generate-rpm.url.

Due to same reason, its fallback should be "package.homepage". package.repository should be also used for second fallback when neither package.metadata.generate-rpm.url nor package.homepage exists. Because today there is many projects where package.repository present but package.url not present.