### PR TITLE
Use raw pointer for `Dependency` to `u8` slice conversion

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -333,7 +333,9 @@ documentation.workspace = true
     #[test]
     fn test_table_to_dependencies() {
         fn dependency_to_u8_slice(dep: &Dependency) -> &[u8] {
-            unsafe { std::mem::transmute_copy(dep) }
+            let dep: *const Dependency = dep;
+            let dep: *const u8 = dep as *const u8;
+            unsafe { std::slice::from_raw_parts(dep, std::mem::size_of::<&Dependency>()) }
         }
 
         let mut table = Table::new();


### PR DESCRIPTION
`std::mem::transmute_copy` causes undefined behavior if the destination type and target type has different sizes. This PR eliminates this issue by using raw pointer to the data and converting it to a `u8` slice with the given size.

More detailed explanation: https://stackoverflow.com/questions/25917260/getting-raw-bytes-from-packed-struct

Fixes #62
