### PR TITLE
Build with `--locked` flag during CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --locked
     - name: Run tests
       run: cargo test --verbose
     - name: Package


### PR DESCRIPTION
This PR updates the continuous integration workflow to always build with `--locked` flag for making sure that `Cargo.lock` is up-to-date.

It will help spotting issues like bumping the version in `Cargo.toml` but not in `Cargo.lock` which is common for Rust projects.
