### PR TITLE
Add --profile command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Because all packages in the workspace share a common output directory that is lo
 
 ### Cross compilation
 
-This command supports `--target-dir` and `--target` option like `cargo build`.
+This command supports `--target-dir`, `--target`, and `--profile` options like `cargo build`.
 Depending on these options, this command changes the RPM package file location and replaces `target/release/` of
 the source locations of the assets.
 
@@ -188,6 +188,9 @@ In this case, the source of the asset `{ source = "target/release/XXX", dest = "
 
 You can use `CARGO_BUILD_TARGET` environment variable instead of `--target` option and `CARGO_BUILD_TARGET_DIR` or
 `CARGO_TARGET_DIR` instead of `--target-dir`.
+
+Similarly, if using a custom build profile with, for example, `--profile custom` the source of the asset
+`{ source = "target/release/XXX" }` will be treated as `target/custom/XXX`.
 
 ### Payload compress type
 

--- a/src/build_target.rs
+++ b/src/build_target.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 pub struct BuildTarget {
     pub target_dir: Option<String>,
     pub target: Option<String>,
+    pub profile: Option<String>,
     pub arch: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,12 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
     );
     opts.optopt(
         "",
+        "profile",
+        "Select which build profile to package. Defaults to \"release\".",
+        "PROFILE",
+    );
+    opts.optopt(
+        "",
         "payload-compress",
         "Compression type of package payloads. \
         none, gzip or zstd(Default).",
@@ -178,6 +184,9 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
     }
     if let Some(target_dir) = opt_matches.opt_str("target-dir") {
         build_target.target_dir = Some(target_dir);
+    }
+    if let Some(profile) = opt_matches.opt_str("profile") {
+        build_target.profile = Some(profile);
     }
     let payload_compress = opt_matches
         .opt_str("payload-compress")


### PR DESCRIPTION
When expanding an asset path, currently only the "target/release/" prefix could be remapped. By comprehending the build profile, path expansion can happen for "target/<profile>". This enables use of both alternative target-triple and build profiles.

For example, given the following asset configuration in Cargo.toml:

    [package.metadata.generate-rpm]
    assets = [
      { source = "target/my-profile/my-exe", dest = "/usr/bin/", mode = "755" },
    ]

rpms can be generated for multiple target triples, such as:

    cargo generate-rpm --profile my-profile --target x86_64-unknown-linux-musl
    cargo generate-rpm --profile my-profile --target i668-unknown-linux-musl

with the paths for the "my-exe" executable expanded correctly to:

    target/x86_64-unknown-linux-musl/my-profile/my-exe
    target/i686-unknown-linux-musl/my-profile/my-exe

This behavior is consistent with cargo-deb, which also has a --profile option for the same purpose.