### PR TITLE
Fixed warning displayed for file paths before expansion when `--target` and `--profile` options specified and the file does not exist.

### DIFF
--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -134,7 +134,7 @@ impl FileInfo<'_, '_, '_, '_> {
             }
         }
 
-        Err(ConfigError::AssetFileNotFound(PathBuf::from(&self.source)))
+        Err(ConfigError::AssetFileNotFound(PathBuf::from(source)))
     }
 
     fn generate_rpm_file_options<T: ToString>(&self, dest: T) -> RPMFileOptions {


### PR DESCRIPTION
When `--target` specified and the asset file of rust artifact does not exist, the error message should contain the expanded path such as: `target/my-target/program_name`, but actually contains the original path: `target/release/program_name`