### PR TITLE
Revert rpm crate back to v0.9.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = "0.10.0"
+rpm = "0.9.0-alpha.1"
 toml = "0.7"
 cargo_toml = "0.15"
 getopts = "0.2"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use cargo_toml::Error as CargoTomlError;
 use cargo_toml::Manifest;
-use rpm::{CompressionType, Dependency, RPMBuilder};
+use rpm::{Compressor, Dependency, RPMBuilder};
 use toml::value::Table;
 
 use crate::auto_req::{find_requires, AutoReqMode};
@@ -171,7 +171,7 @@ impl Config {
         let parent = self.manifest_path.parent().unwrap();
 
         let mut builder = RPMBuilder::new(name, version, license, arch.as_str(), desc)
-            .compression(CompressionType::from_str(rpm_builder_config.payload_compress)?);
+            .compression(Compressor::from_str(rpm_builder_config.payload_compress)?);
         for (idx, file) in files.iter().enumerate() {
             let entries =
                 file.generate_rpm_file_entry(rpm_builder_config.build_target, parent, idx)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetti
         "",
         "payload-compress",
         "Compression type of package payloads. \
-        none, gzip, zstd(Default) or xz.",
+        none, gzip or zstd(Default).",
         "TYPE",
     );
     opts.optmulti(


### PR DESCRIPTION
Reverts cat-in-136/cargo-generate-rpm#75 and bump rpm to v0.11.0 because of regrade for none compression type feature

Details is written in https://github.com/cat-in-136/cargo-generate-rpm/commit/dc6b4c6ee3940d8b4b8d8df75b7530c10b0fb671#r114846727