### PR TITLE
Replace `rpm-rs` with `rpm` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 from Cargo project.
 
 This command does not depend on `rpmbuild` and generates an RPM package file without a spec file by
-using [rpm-rs](https://crates.io/crates/rpm-rs).
+using the [`rpm`](https://crates.io/crates/rpm) crate.
 
 ![Rust](https://github.com/cat-in-136/cargo-generate-rpm/workflows/Rust/badge.svg)
 [![cargo-generate-rpm at crates.io](https://img.shields.io/crates/v/cargo-generate-rpm.svg)](https://crates.io/crates/cargo-generate-rpm)


### PR DESCRIPTION
`cargo-generate-rpm` currently relies on the `rpm` crate, while readme links the older `rpm-rs` crate.