### PR TITLE
Update rpm, migrate to clap and add source_date_epoch flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,12 @@ repository = "https://github.com/cat-in-136/cargo-generate-rpm"
 version = "0.11.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 glob = "0.3.0"
-rpm = "0.9.0-alpha.1"
+rpm = { git = "https://github.com/newpavlov/rpm", branch = "source_date_epoch", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
-getopts = "0.2"
+clap = { version = "4.3", features = ["derive"] }
 thiserror = "1"
 elf = "0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = { git = "https://github.com/rpm-rs/rpm", rev = "9498e02", default-features = false }
+rpm = { git = "https://github.com/rpm-rs/rpm", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
 clap = { version = "4.3", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = { git = "https://github.com/rpm-rs/rpm", default-features = false }
+rpm = { version = "0.12", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
 clap = { version = "4.3", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = { git = "https://github.com/newpavlov/rpm", branch = "source_date_epoch", default-features = false }
+rpm = { git = "https://github.com/rpm-rs/rpm", rev = "9498e02", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
 clap = { version = "4.3", features = ["derive"] }

--- a/src/auto_req/script.rs
+++ b/src/auto_req/script.rs
@@ -33,7 +33,7 @@ pub(super) fn find_requires<P: AsRef<Path>, S: AsRef<OsStr>>(
         .read_to_string(&mut requires)
         .map_err(|e| AutoReqError::ProcessError(script_path.as_ref().to_os_string(), e))?;
 
-    Ok(requires.trim().split("\n").map(&String::from).collect())
+    Ok(requires.trim().split('\n').map(&String::from).collect())
 }
 
 #[test]

--- a/src/build_target.rs
+++ b/src/build_target.rs
@@ -1,15 +1,30 @@
 use std::env::consts::ARCH;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Default)]
+use crate::cli::Args;
+
+#[derive(Debug, Clone)]
 pub struct BuildTarget {
-    pub target_dir: Option<String>,
-    pub target: Option<String>,
-    pub profile: Option<String>,
-    pub arch: Option<String>,
+    target_dir: Option<String>,
+    target: Option<String>,
+    profile: String,
+    arch: Option<String>,
 }
 
 impl BuildTarget {
+    pub fn new(args: &Args) -> Self {
+        Self {
+            target_dir: args.target_dir.clone(),
+            target: args.target.clone(),
+            profile: args.profile.clone(),
+            arch: args.arch.clone(),
+        }
+    }
+
+    pub fn profile(&self) -> &str {
+        self.profile.as_str()
+    }
+
     pub fn build_target_path(&self) -> PathBuf {
         if let Some(target_dir) = &self.target_dir {
             PathBuf::from(&target_dir)
@@ -36,8 +51,8 @@ impl BuildTarget {
             let arch = self
                 .target
                 .as_ref()
-                .and_then(|v| v.splitn(2, "-").nth(0))
-                .unwrap_or_else(|| ARCH);
+                .and_then(|v| v.split('-').next())
+                .unwrap_or(ARCH);
 
             match arch {
                 "x86" => "i586",
@@ -57,12 +72,13 @@ mod test {
 
     #[test]
     fn test_build_target_path() {
-        let target = BuildTarget::default();
+        let args = crate::cli::Args::default();
+        let target = BuildTarget::new(&args);
         assert_eq!(target.build_target_path(), PathBuf::from("target"));
 
         let target = BuildTarget {
             target_dir: Some("/tmp/foobar/target".to_string()),
-            ..Default::default()
+            ..target
         };
         assert_eq!(
             target.build_target_path(),
@@ -72,15 +88,16 @@ mod test {
 
     #[test]
     fn test_target_path() {
-        let target = BuildTarget::default();
+        let args = crate::cli::Args::default();
+        let default_target = BuildTarget::new(&args);
         assert_eq!(
-            target.target_path("release"),
+            default_target.target_path("release"),
             PathBuf::from("target/release")
         );
 
         let target = BuildTarget {
             target: Some("x86_64-unknown-linux-gnu".to_string()),
-            ..Default::default()
+            ..default_target.clone()
         };
         assert_eq!(
             target.target_path("release"),
@@ -89,7 +106,7 @@ mod test {
 
         let target = BuildTarget {
             target_dir: Some("/tmp/foobar/target".to_string()),
-            ..Default::default()
+            ..default_target.clone()
         };
         assert_eq!(
             target.target_path("debug"),
@@ -99,7 +116,7 @@ mod test {
         let target = BuildTarget {
             target_dir: Some("/tmp/foobar/target".to_string()),
             target: Some("x86_64-unknown-linux-gnu".to_string()),
-            ..Default::default()
+            ..default_target
         };
         assert_eq!(
             target.target_path("debug"),

--- a/src/build_target.rs
+++ b/src/build_target.rs
@@ -1,7 +1,7 @@
 use std::env::consts::ARCH;
 use std::path::{Path, PathBuf};
 
-use crate::cli::Args;
+use crate::cli::Cli;
 
 #[derive(Debug, Clone)]
 pub struct BuildTarget {
@@ -12,7 +12,7 @@ pub struct BuildTarget {
 }
 
 impl BuildTarget {
-    pub fn new(args: &Args) -> Self {
+    pub fn new(args: &Cli) -> Self {
         Self {
             target_dir: args.target_dir.clone(),
             target: args.target.clone(),
@@ -72,7 +72,7 @@ mod test {
 
     #[test]
     fn test_build_target_path() {
-        let args = crate::cli::Args::default();
+        let args = crate::cli::Cli::default();
         let target = BuildTarget::new(&args);
         assert_eq!(target.build_target_path(), PathBuf::from("target"));
 
@@ -88,7 +88,7 @@ mod test {
 
     #[test]
     fn test_target_path() {
-        let args = crate::cli::Args::default();
+        let args = crate::cli::Cli::default();
         let default_target = BuildTarget::new(&args);
         assert_eq!(
             default_target.target_path("release"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,7 +58,7 @@ pub struct Cli {
     /// This value can also be provided using the SOURCE_DATE_EPOCH
     /// enviroment variable.
     #[arg(long)]
-    pub source_date_epoch: Option<u32>,
+    pub source_date: Option<u32>,
 
     /// Overwrite metadata with TOML file. If "#dotted.key"
     /// suffixed, load "dotted.key" table instead of the root

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,156 @@
+use clap::{builder::PossibleValue, Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
+
+/// Arguments of the command line interface
+#[derive(Debug, Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    GenerateRpm(Args),
+}
+
+/// Arguments of the command line interface
+#[derive(Debug, clap::Args)]
+pub struct Args {
+    /// Target arch of generated package.
+    #[arg(short, long)]
+    pub arch: Option<String>,
+
+    /// Output file or directory.
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Name of a crate in the workspace for which
+    /// RPM package will be generated.
+    #[arg(short, long)]
+    pub package: Option<String>,
+
+    /// Automatic dependency processing mode.
+    #[arg(long)]
+    pub auto_req: Option<AutoReqMode>,
+
+    /// Sub-directory name for all generated artifacts. May be
+    /// specified with CARGO_BUILD_TARGET environment
+    /// variable.
+    #[arg(long)]
+    pub target: Option<String>,
+
+    /// Directory for all generated artifacts. May be
+    /// specified with CARGO_BUILD_TARGET_DIR or
+    /// CARGO_TARGET_DIR environment variables.
+    #[arg(long)]
+    pub target_dir: Option<String>,
+
+    /// Build profile for packaging.
+    #[arg(long, default_value = "release")]
+    pub profile: String,
+
+    /// Compression type of package payload.
+    #[arg(long, default_value = "zstd")]
+    pub payload_compress: Compression,
+
+    /// Timestamp in seconds since the UNIX Epoch for clamping
+    /// modification time of included files and package build time.
+    ///
+    /// This value can also be provided using the SOURCE_DATE_EPOCH
+    /// enviroment variable.
+    #[arg(long)]
+    pub source_date_epoch: Option<u32>,
+
+    /// Overwrite metadata with TOML file. If "#dotted.key"
+    /// suffixed, load "dotted.key" table instead of the root
+    /// table.
+    #[arg(long, value_delimiter = ',')]
+    pub metadata_overwrite: Vec<String>,
+
+    /// Overwrite metadata with TOML text.
+    #[arg(short, long, value_delimiter = ',')]
+    pub set_metadata: Vec<String>,
+
+    /// Shortcut to --metadata-overwrite=path/to/Cargo.toml#package.metadata.generate-rpm.variants.VARIANT
+    #[arg(long, value_delimiter = ',')]
+    pub variant: Vec<String>,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        let Commands::GenerateRpm(args) = Cli::parse_from(["generate-rpm"]).command;
+        args
+    }
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Default)]
+pub enum Compression {
+    None,
+    Gzip,
+    #[default]
+    Zstd,
+    Xz,
+}
+
+impl From<Compression> for rpm::CompressionWithLevel {
+    fn from(val: Compression) -> Self {
+        let ct = match val {
+            Compression::None => rpm::CompressionType::None,
+            Compression::Gzip => rpm::CompressionType::Gzip,
+            Compression::Zstd => rpm::CompressionType::Zstd,
+            Compression::Xz => rpm::CompressionType::Xz,
+        };
+        ct.into()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AutoReqMode {
+    Disabled,
+    Builtin,
+    FindRequires,
+    Script(String),
+}
+
+static AUTO_REQ_VARIANTS: &[AutoReqMode] = &[
+    AutoReqMode::Disabled,
+    AutoReqMode::Builtin,
+    AutoReqMode::FindRequires,
+    AutoReqMode::Script(String::new()),
+];
+
+impl ValueEnum for AutoReqMode {
+    fn value_variants<'a>() -> &'a [Self] {
+        AUTO_REQ_VARIANTS
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        use AutoReqMode::*;
+
+        let val = match self {
+            Disabled => {
+                PossibleValue::new("disabled").help("Disable automatic discovery of dependencies")
+            }
+            Builtin => {
+                PossibleValue::new("builtin").help("Use the builtin procedure based on ldd.")
+            }
+            FindRequires => PossibleValue::new("find-requires")
+                .help("Use the external program specified in RPM_FIND_REQUIRES."),
+            _ => PossibleValue::new("/path/to/find-requires")
+                .help("Use the specified external program."),
+        };
+        Some(val)
+    }
+
+    // Provided method
+    fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+        let lowercase = String::from(input).to_lowercase();
+        let val = if ignore_case { &lowercase } else { input };
+        Ok(match val {
+            "disabled" => Self::Disabled,
+            "builtin" => Self::Builtin,
+            "find-requires" => Self::FindRequires,
+            _ => Self::Script(input.into()),
+        })
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,21 +1,20 @@
-use clap::{builder::PossibleValue, Parser, Subcommand, ValueEnum};
+use clap::{builder::PossibleValue, Parser, ValueEnum};
 use std::path::PathBuf;
+
+/// Wrapper used when the application is executed as Cargo plugin
+#[derive(Debug, Parser)]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+pub enum CargoWrapper {
+    GenerateRpm(Cli),
+}
 
 /// Arguments of the command line interface
 #[derive(Debug, Parser)]
+#[command(name = "cargo-generate-rpm")]
+#[command(bin_name = "cargo-generate-rpm")]
+#[command(author, version, about, long_about = None)]
 pub struct Cli {
-    #[command(subcommand)]
-    pub command: Commands,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum Commands {
-    GenerateRpm(Args),
-}
-
-/// Arguments of the command line interface
-#[derive(Debug, clap::Args)]
-pub struct Args {
     /// Target arch of generated package.
     #[arg(short, long)]
     pub arch: Option<String>,
@@ -76,10 +75,9 @@ pub struct Args {
     pub variant: Vec<String>,
 }
 
-impl Default for Args {
+impl Default for Cli {
     fn default() -> Self {
-        let Commands::GenerateRpm(args) = Cli::parse_from(["generate-rpm"]).command;
-        args
+        Cli::parse_from([""])
     }
 }
 

--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -314,7 +314,7 @@ mod test {
     #[test]
     fn test_generate_rpm_file_path() {
         let tempdir = tempfile::tempdir().unwrap();
-        let args = crate::cli::Args::default();
+        let args = crate::cli::Cli::default();
         let target = BuildTarget::new(&args);
         let file_info = FileInfo {
             source: "README.md",
@@ -381,7 +381,7 @@ mod test {
             )]
         );
 
-        let args = crate::cli::Args {
+        let args = crate::cli::Cli {
             target_dir: Some(
                 tempdir
                     .path()
@@ -430,7 +430,7 @@ mod test {
             config: false,
             doc: false,
         };
-        let args = crate::cli::Args {
+        let args = crate::cli::Cli {
             target_dir: Some(
                 tempdir
                     .path()

--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -1,5 +1,4 @@
 use glob::glob;
-use rpm::RPMFileOptions;
 use toml::value::Table;
 
 use crate::build_target::BuildTarget;
@@ -137,8 +136,8 @@ impl FileInfo<'_, '_, '_, '_> {
         Err(ConfigError::AssetFileNotFound(PathBuf::from(source)))
     }
 
-    fn generate_rpm_file_options<T: ToString>(&self, dest: T) -> RPMFileOptions {
-        let mut rpm_file_option = RPMFileOptions::new(dest.to_string());
+    fn generate_rpm_file_options<T: ToString>(&self, dest: T) -> rpm::FileOptions {
+        let mut rpm_file_option = rpm::FileOptions::new(dest.to_string());
         if let Some(user) = self.user {
             rpm_file_option = rpm_file_option.user(user);
         }
@@ -162,7 +161,7 @@ impl FileInfo<'_, '_, '_, '_> {
         build_target: &BuildTarget,
         parent: P,
         idx: usize,
-    ) -> Result<Vec<(PathBuf, RPMFileOptions)>, ConfigError> {
+    ) -> Result<Vec<(PathBuf, rpm::FileOptions)>, ConfigError> {
         self.generate_expanded_path(build_target, parent, idx)
             .map(|p| {
                 p.iter()

--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -107,14 +107,17 @@ impl FileInfo<'_, '_, '_, '_> {
         parent: P,
         idx: usize,
     ) -> Result<Vec<(PathBuf, String)>, ConfigError> {
-        let profile = build_target.profile();
+        let dir_name = match build_target.profile() {
+            "dev" => "debug",
+            p => p,
+        };
         let source = self
             .source
             .strip_prefix("target/release/")
-            .or_else(|| self.source.strip_prefix(&format!("target/{profile}/")))
+            .or_else(|| self.source.strip_prefix(&format!("target/{dir_name}/")))
             .and_then(|rel_path| {
                 build_target
-                    .target_path(profile)
+                    .target_path(dir_name)
                     .join(rel_path)
                     .to_str()
                     .map(|v| v.to_string())

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -164,7 +164,7 @@ impl<'a> MetadataConfig<'a> {
     pub fn new(metadata: &'a Table, branch_path: Option<String>) -> Self {
         Self {
             metadata,
-            branch_path: branch_path.map(|v| v.to_string()),
+            branch_path,
         }
     }
 
@@ -298,7 +298,7 @@ impl<'a> CompoundMetadataConfig<'a> {
         F: Fn(&MetadataConfig<'a>) -> Result<Option<T>, ConfigError>,
     {
         for item in self.config.iter().rev() {
-            match func(&item) {
+            match func(item) {
                 v @ (Ok(Some(_)) | Err(_)) => return v,
                 Ok(None) => continue,
             }
@@ -377,11 +377,11 @@ mod test {
         assert_eq!(metadata_config.get_str("not-exist").unwrap(), None);
         assert!(matches!(
             metadata_config.get_str("int"),
-            Err(ConfigError::WrongType(v, "string")) if v == "int".to_string()
+            Err(ConfigError::WrongType(v, "string")) if v == "int"
         ));
         assert!(matches!(
             metadata_config.get_string_or_i64("array"),
-            Err(ConfigError::WrongType(v, "string or integer")) if v == "array".to_string()
+            Err(ConfigError::WrongType(v, "string or integer")) if v == "array"
         ));
 
         let metadata_config = MetadataConfig {
@@ -390,11 +390,11 @@ mod test {
         };
         assert!(matches!(
             metadata_config.get_str("int"),
-            Err(ConfigError::WrongType(v, "string")) if v == "branch.int".to_string()
+            Err(ConfigError::WrongType(v, "string")) if v == "branch.int"
         ));
         assert!(matches!(
             metadata_config.get_string_or_i64("array"),
-            Err(ConfigError::WrongType(v, "string or integer")) if v == "branch.array".to_string()
+            Err(ConfigError::WrongType(v, "string or integer")) if v == "branch.array"
         ));
     }
 
@@ -413,7 +413,7 @@ mod test {
         let metadata_config = metadata
             .iter()
             .map(|v| MetadataConfig {
-                metadata: &v,
+                metadata: v,
                 branch_path: None,
             })
             .collect::<Vec<_>>();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,39 +15,6 @@ use metadata::{CompoundMetadataConfig, ExtraMetaData, MetadataConfig, TomlValueH
 mod file_info;
 mod metadata;
 
-#[derive(Debug, Clone, Default)]
-pub enum PayloadCompressType {
-    None,
-    Gzip,
-    #[default]
-    Zstd,
-    Xz,
-}
-
-impl FromStr for PayloadCompressType {
-    type Err = PayloadCompressError;
-    fn from_str(raw: &str) -> Result<Self, Self::Err> {
-        match raw {
-            "none" => Ok(PayloadCompressType::None),
-            "gzip" => Ok(PayloadCompressType::Gzip),
-            "zstd" => Ok(PayloadCompressType::Zstd),
-            "xz" => Ok(PayloadCompressType::Xz),
-            _ => Err(PayloadCompressError::UnsupportedType(raw.to_string())),
-        }
-    }
-}
-
-impl From<PayloadCompressType> for CompressionType {
-    fn from(value: PayloadCompressType) -> Self {
-        match value {
-            PayloadCompressType::None => Self::None,
-            PayloadCompressType::Gzip => Self::Gzip,
-            PayloadCompressType::Zstd => Self::Zstd,
-            PayloadCompressType::Xz => Self::Xz,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum ExtraMetadataSource {
     File(PathBuf, Option<String>),
@@ -425,7 +392,7 @@ documentation.workspace = true
         let builder = config.create_rpm_builder(cfg);
 
         assert!(if Path::new("target/release/cargo-generate-rpm").exists() {
-            matches!(builder, Ok(_))
+            builder.is_ok()
         } else {
             matches!(builder, Err(Error::Config(ConfigError::AssetFileNotFound(path))) if path.to_str() == Some("target/release/cargo-generate-rpm"))
         });

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ use toml::value::Table;
 
 use crate::auto_req::{find_requires, AutoReqMode};
 use crate::build_target::BuildTarget;
-use crate::cli::Args;
+use crate::cli::Cli;
 use crate::error::{ConfigError, Error};
 use file_info::FileInfo;
 use metadata::{CompoundMetadataConfig, ExtraMetaData, MetadataConfig, TomlValueHelper};
@@ -24,11 +24,11 @@ pub enum ExtraMetadataSource {
 #[derive(Debug)]
 pub struct RpmBuilderConfig<'a> {
     build_target: &'a BuildTarget,
-    args: &'a Args,
+    args: &'a Cli,
 }
 
 impl<'a> RpmBuilderConfig<'a> {
-    pub fn new(build_target: &'a BuildTarget, args: &'a Args) -> RpmBuilderConfig<'a> {
+    pub fn new(build_target: &'a BuildTarget, args: &'a Cli) -> RpmBuilderConfig<'a> {
         RpmBuilderConfig { build_target, args }
     }
 }
@@ -384,7 +384,7 @@ documentation.workspace = true
     #[test]
     fn test_config_create_rpm_builder() {
         let config = Config::new(Path::new("."), None, &[]).unwrap();
-        let args = crate::cli::Args {
+        let args = crate::cli::Cli {
             ..Default::default()
         };
         let target = BuildTarget::new(&args);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -159,12 +159,12 @@ impl Config {
         let mut builder = RPMBuilder::new(name, version, license, arch.as_str(), desc)
             .compression(cfg.args.payload_compress);
         builder = if let Some(t) = cfg.args.source_date_epoch {
-            builder.source_date_epoch(t)
+            builder.source_date(t)
         } else if let Ok(t) = std::env::var("SOURCE_DATE_EPOCH") {
             let t = t
                 .parse::<u32>()
                 .map_err(|err| Error::EnvError("SOURCE_DATE_EPOCH", err.to_string()))?;
-            builder.source_date_epoch(t)
+            builder.source_date(t)
         } else {
             builder
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -158,7 +158,7 @@ impl Config {
 
         let mut builder = rpm::PackageBuilder::new(name, version, license, arch.as_str(), desc)
             .compression(cfg.args.payload_compress);
-        builder = if let Some(t) = cfg.args.source_date_epoch {
+        builder = if let Some(t) = cfg.args.source_date {
             builder.source_date(t)
         } else if let Ok(t) = std::env::var("SOURCE_DATE_EPOCH") {
             let t = t

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,13 +1,13 @@
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use cargo_toml::Error as CargoTomlError;
 use cargo_toml::Manifest;
-use rpm::{Compressor, Dependency, RPMBuilder};
+use rpm::{Dependency, RPMBuilder};
 use toml::value::Table;
 
 use crate::auto_req::{find_requires, AutoReqMode};
 use crate::build_target::BuildTarget;
+use crate::cli::Args;
 use crate::error::{ConfigError, Error};
 use file_info::FileInfo;
 use metadata::{CompoundMetadataConfig, ExtraMetaData, MetadataConfig, TomlValueHelper};
@@ -22,23 +22,14 @@ pub enum ExtraMetadataSource {
 }
 
 #[derive(Debug)]
-pub struct RpmBuilderConfig<'a, 'b> {
+pub struct RpmBuilderConfig<'a> {
     build_target: &'a BuildTarget,
-    auto_req_mode: AutoReqMode,
-    payload_compress: &'b str,
+    args: &'a Args,
 }
 
-impl<'a, 'b> RpmBuilderConfig<'a, 'b> {
-    pub fn new(
-        build_target: &'a BuildTarget,
-        auto_req_mode: AutoReqMode,
-        payload_compress: &'b str,
-    ) -> RpmBuilderConfig<'a, 'b> {
-        RpmBuilderConfig {
-            build_target,
-            auto_req_mode,
-            payload_compress,
-        }
+impl<'a> RpmBuilderConfig<'a> {
+    pub fn new(build_target: &'a BuildTarget, args: &'a Args) -> RpmBuilderConfig<'a> {
+        RpmBuilderConfig { build_target, args }
     }
 }
 
@@ -89,7 +80,7 @@ impl Config {
 
         let extra_metadata = extra_metadata
             .iter()
-            .map(|v| ExtraMetaData::new(v))
+            .map(ExtraMetaData::new)
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Config {
@@ -110,7 +101,7 @@ impl Config {
                 .as_str()
                 .ok_or(ConfigError::WrongDependencyVersion(key.clone()))?
                 .trim();
-            let ver_vec = ver.trim().split_whitespace().collect::<Vec<_>>();
+            let ver_vec = ver.split_whitespace().collect::<Vec<_>>();
             let dependency = match ver_vec.as_slice() {
                 [] | ["*"] => Ok(Dependency::any(key)),
                 ["<", ver] => Ok(Dependency::less(key.as_str(), ver.trim())),
@@ -125,10 +116,7 @@ impl Config {
         Ok(dependencies)
     }
 
-    pub fn create_rpm_builder(
-        &self,
-        rpm_builder_config: RpmBuilderConfig,
-    ) -> Result<RPMBuilder, Error> {
+    pub fn create_rpm_builder(&self, cfg: RpmBuilderConfig) -> Result<RPMBuilder, Error> {
         let mut metadata_config = Vec::new();
         metadata_config.push(MetadataConfig::new_from_manifest(&self.manifest)?);
         for v in &self.extra_metadata {
@@ -141,9 +129,7 @@ impl Config {
             .package
             .as_ref()
             .ok_or(ConfigError::Missing("package".to_string()))?;
-        let name = metadata
-            .get_str("name")?
-            .unwrap_or_else(|| pkg.name.as_str());
+        let name = metadata.get_str("name")?.unwrap_or(pkg.name.as_str());
         let version = match metadata.get_str("version")? {
             Some(v) => v,
             None => pkg.version.get()?,
@@ -153,7 +139,7 @@ impl Config {
             (None, None) => Err(ConfigError::Missing("package.license".to_string()))?,
             (None, Some(v)) => v.get()?,
         };
-        let arch = rpm_builder_config.build_target.binary_arch();
+        let arch = cfg.build_target.binary_arch();
         let desc = match (
             metadata.get_str("summary")?,
             metadata.get_str("description")?,
@@ -171,11 +157,20 @@ impl Config {
         let parent = self.manifest_path.parent().unwrap();
 
         let mut builder = RPMBuilder::new(name, version, license, arch.as_str(), desc)
-            .compression(Compressor::from_str(rpm_builder_config.payload_compress)?);
+            .compression(cfg.args.payload_compress);
+        builder = if let Some(t) = cfg.args.source_date_epoch {
+            builder.source_date_epoch(t)
+        } else if let Ok(t) = std::env::var("SOURCE_DATE_EPOCH") {
+            let t = t
+                .parse::<u32>()
+                .map_err(|err| Error::EnvError("SOURCE_DATE_EPOCH", err.to_string()))?;
+            builder.source_date_epoch(t)
+        } else {
+            builder
+        };
         let mut expanded_file_paths = vec![];
         for (idx, file) in files.iter().enumerate() {
-            let entries =
-                file.generate_rpm_file_entry(rpm_builder_config.build_target, parent, idx)?;
+            let entries = file.generate_rpm_file_entry(cfg.build_target, parent, idx)?;
             for (file_source, options) in entries {
                 expanded_file_paths.push(file_source.clone());
                 builder = builder.with_file(file_source, options)?;
@@ -228,13 +223,13 @@ impl Config {
                 builder = builder.requires(dependency);
             }
         }
-        let auto_req = if rpm_builder_config.auto_req_mode == AutoReqMode::Auto
-            && matches!(metadata.get_str("auto-req")?, Some("no") | Some("disabled"))
-        {
-            AutoReqMode::Disabled
-        } else {
-            rpm_builder_config.auto_req_mode
+
+        let meta_aut_req = metadata.get_str("auto-req")?;
+        let auto_req = match (&cfg.args.auto_req, meta_aut_req) {
+            (None, Some("no" | "disabled")) => AutoReqMode::Disabled,
+            (r, _) => r.into(),
         };
+
         for requires in find_requires(expanded_file_paths, auto_req)? {
             builder = builder.requires(Dependency::any(requires));
         }
@@ -287,7 +282,7 @@ mod test {
 
         std::fs::create_dir(&workspace_dir).unwrap();
         std::fs::write(
-            &workspace_dir.join("Cargo.toml"),
+            workspace_dir.join("Cargo.toml"),
             r#"
 [workspace]
 members = ["bar"]
@@ -302,7 +297,7 @@ documentation = "https://example.com/bar"
         .unwrap();
         std::fs::create_dir(&project_dir).unwrap();
         std::fs::write(
-            &project_dir.join("Cargo.toml"),
+            project_dir.join("Cargo.toml"),
             r#"
 [package]
 name = "bar"
@@ -388,11 +383,12 @@ documentation.workspace = true
     #[test]
     fn test_config_create_rpm_builder() {
         let config = Config::new(Path::new("."), None, &[]).unwrap();
-        let builder = config.create_rpm_builder(RpmBuilderConfig::new(
-            &BuildTarget::default(),
-            AutoReqMode::Disabled,
-            "zstd",
-        ));
+        let args = crate::cli::Args {
+            ..Default::default()
+        };
+        let target = BuildTarget::new(&args);
+        let cfg = RpmBuilderConfig::new(&target, &args);
+        let builder = config.create_rpm_builder(cfg);
 
         assert!(if Path::new("target/release/cargo-generate-rpm").exists() {
             matches!(builder, Ok(_))

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,8 +45,6 @@ pub enum ConfigError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum AutoReqError {
-    #[error("Wrong auto-req mode")]
-    WrongMode,
     #[error("Failed to execute `{}`: {1}", .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
     #[error(transparent)]
@@ -71,6 +69,8 @@ pub enum Error {
     CargoToml(#[from] CargoTomlError),
     #[error(transparent)]
     Config(#[from] ConfigError),
+    #[error("Invalid value of enviroment variable {0}: {1}")]
+    EnvError(&'static str, String),
     #[error(transparent)]
     ParseTomlFile(#[from] FileAnnotatedError<TomlDeError>),
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use cargo_toml::Error as CargoTomlError;
-use rpm::RPMError;
 use std::error::Error as StdError;
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
@@ -78,7 +77,7 @@ pub enum Error {
     #[error(transparent)]
     AutoReq(#[from] AutoReqError),
     #[error(transparent)]
-    Rpm(#[from] RPMError),
+    Rpm(#[from] rpm::Error),
     #[error("{1}: {0}")]
     FileIo(PathBuf, #[source] IoError),
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,12 +64,6 @@ pub enum AutoReqError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PayloadCompressError {
-    #[error("Unsupported payload compress type: {0}")]
-    UnsupportedType(String),
-}
-
-#[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Cargo.toml: {0}")]
     CargoToml(#[from] CargoTomlError),
@@ -85,8 +79,6 @@ pub enum Error {
     AutoReq(#[from] AutoReqError),
     #[error(transparent)]
     Rpm(#[from] RPMError),
-    #[error(transparent)]
-    PayloadCompress(#[from] PayloadCompressError),
     #[error("{1}: {0}")]
     FileIo(PathBuf, #[source] IoError),
     #[error(transparent)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,246 +1,90 @@
-extern crate core;
-
-use crate::auto_req::AutoReqMode;
-use crate::build_target::BuildTarget;
-use crate::config::{Config, ExtraMetadataSource, RpmBuilderConfig};
-use crate::error::Error;
-use getopts::Options;
-use std::convert::TryFrom;
-use std::env;
-use std::fs::{create_dir_all, File};
-use std::path::{Path, PathBuf};
+use crate::{build_target::BuildTarget, config::RpmBuilderConfig};
+use clap::Parser;
+use cli::Commands;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 mod auto_req;
 mod build_target;
+mod cli;
 mod config;
 mod error;
 
-#[derive(Debug)]
-struct CliSetting {
-    auto_req_mode: AutoReqMode,
-    payload_compress: String,
-    extra_metadata: Vec<ExtraMetadataSource>,
+use config::{Config, ExtraMetadataSource};
+use error::Error;
+
+fn collect_metadata(args: &cli::Args) -> Vec<config::ExtraMetadataSource> {
+    args.metadata_overwrite
+        .iter()
+        .map(|v| {
+            let (file, branch) = match v.split_once('#') {
+                None => (PathBuf::from(v), None),
+                Some((file, branch)) => (PathBuf::from(file), Some(branch.to_string())),
+            };
+            ExtraMetadataSource::File(file, branch)
+        })
+        .chain(
+            args.set_metadata
+                .iter()
+                .map(|v| ExtraMetadataSource::Text(v.to_string())),
+        )
+        .chain(args.variant.iter().map(|v| {
+            let file = match &args.package {
+                Some(package) => Config::create_cargo_toml_path(package),
+                None => Config::create_cargo_toml_path(""),
+            };
+            let branch = String::from("package.metadata.generate-rpm.variants.") + v;
+            ExtraMetadataSource::File(file, Some(branch))
+        }))
+        .collect::<Vec<_>>()
 }
 
-fn process(
-    build_target: &BuildTarget,
-    target_path: Option<PathBuf>,
-    package: Option<String>,
-    setting: CliSetting,
-) -> Result<(), Error> {
-    let config = if let Some(p) = package {
-        Config::new(
-            Path::new(&p),
-            Some(Path::new("")),
-            setting.extra_metadata.as_slice(),
-        )?
-    } else {
-        Config::new(Path::new(""), None, setting.extra_metadata.as_slice())?
-    };
+fn main() -> Result<(), Error> {
+    let Commands::GenerateRpm(args) = cli::Cli::parse().command;
 
+    let build_target = BuildTarget::new(&args);
+    let extra_metadata = collect_metadata(&args);
+
+    let config = if let Some(p) = &args.package {
+        Config::new(Path::new(p), Some(Path::new("")), &extra_metadata)?
+    } else {
+        Config::new(Path::new(""), None, &extra_metadata)?
+    };
     let rpm_pkg = config
-        .create_rpm_builder(RpmBuilderConfig::new(
-            build_target,
-            setting.auto_req_mode,
-            setting.payload_compress.as_str(),
-        ))?
+        .create_rpm_builder(RpmBuilderConfig::new(&build_target, &args))?
         .build()?;
 
-    let default_file_name = build_target.target_path("generate-rpm").join(format!(
-        "{}-{}{}{}.rpm",
-        rpm_pkg.metadata.get_name()?,
-        rpm_pkg.metadata.get_version()?,
-        rpm_pkg
-            .metadata
-            .get_release()
-            .map(|v| format!("-{}", v))
-            .unwrap_or_default(),
-        rpm_pkg
-            .metadata
-            .get_arch()
-            .map(|v| format!(".{}", v))
-            .unwrap_or_default(),
-    ));
+    let pkg_name = rpm_pkg.metadata.get_name()?;
+    let pkg_version = rpm_pkg.metadata.get_version()?;
+    let pkg_release = rpm_pkg
+        .metadata
+        .get_release()
+        .map(|v| format!("-{}", v))
+        .unwrap_or_default();
+    let pkg_arch = rpm_pkg
+        .metadata
+        .get_arch()
+        .map(|v| format!(".{}", v))
+        .unwrap_or_default();
+    let file_name = format!("{pkg_name}-{pkg_version}{pkg_release}{pkg_arch}.rpm");
 
-    let target_file_name = match target_path {
-        Some(path) => {
-            if path.is_dir() {
-                path.join(default_file_name.file_name().unwrap())
-            } else {
-                path
-            }
-        }
-        None => default_file_name,
+    let target_file_name = match args.target.map(PathBuf::from) {
+        Some(path) if path.is_dir() => path.join(file_name),
+        Some(path) => path,
+        None => build_target.target_path("generate-rpm").join(file_name),
     };
 
     if let Some(parent_dir) = target_file_name.parent() {
         if !parent_dir.exists() {
-            create_dir_all(parent_dir)
+            fs::create_dir_all(parent_dir)
                 .map_err(|err| Error::FileIo(parent_dir.to_path_buf(), err))?;
         }
     }
-    let mut f = File::create(&target_file_name)
+    let mut f = fs::File::create(&target_file_name)
         .map_err(|err| Error::FileIo(target_file_name.to_path_buf(), err))?;
     rpm_pkg.write(&mut f)?;
 
     Ok(())
-}
-
-fn parse_arg() -> Result<(BuildTarget, Option<PathBuf>, Option<String>, CliSetting), Error> {
-    let program = env::args().nth(0).unwrap();
-    let mut build_target = BuildTarget::default();
-
-    let mut opts = Options::new();
-    opts.optopt("a", "arch", "set target arch", "ARCH");
-    opts.optopt("o", "output", "set output file or directory", "OUTPUT");
-    opts.optopt(
-        "p",
-        "package",
-        "set a package name of the workspace",
-        "NAME",
-    );
-    opts.optopt(
-        "",
-        "auto-req",
-        "set automatic dependency processing mode, \
-         auto(Default), no, builtin, /path/to/find-requires",
-        "MODE",
-    );
-    opts.optopt(
-        "",
-        "target",
-        "Sub-directory name for all generated artifacts. \
-    May be specified with CARGO_BUILD_TARGET environment variable.",
-        "TARGET-TRIPLE",
-    );
-    opts.optopt(
-        "",
-        "target-dir",
-        "Directory for all generated artifacts. \
-    May be specified with CARGO_BUILD_TARGET_DIR or CARGO_TARGET_DIR environment variables.",
-        "DIRECTORY",
-    );
-    opts.optopt(
-        "",
-        "profile",
-        "Select which build profile to package. Defaults to \"release\".",
-        "PROFILE",
-    );
-    opts.optopt(
-        "",
-        "payload-compress",
-        "Compression type of package payloads. \
-        none, gzip or zstd(Default).",
-        "TYPE",
-    );
-    opts.optmulti(
-        "",
-        "metadata-overwrite",
-        "Overwrite metadata with TOML file. \
-        if \"#dotted.key\" suffixed, load \"dotted.key\" table instead of the root table.",
-        "TOML_FILE",
-    );
-    opts.optmulti(
-        "s",
-        "set-metadata",
-        "Overwrite metadata with TOML text.",
-        "TOML",
-    );
-    opts.optopt(
-        "",
-        "variant",
-        "Shortcut to --metadata-overwrite=path/to/Cargo.toml#package.metadata.generate-rpm.variants.VARIANT",
-        "VARIANT",
-    );
-
-    opts.optflag("h", "help", "print this help menu");
-    opts.optflag("V", "version", "print version information");
-
-    let opt_matches = opts.parse(env::args().skip(1)).unwrap_or_else(|err| {
-        eprintln!("{}: {}", program, err);
-        std::process::exit(1);
-    });
-    if opt_matches.opt_present("h") {
-        println!("{}", opts.usage(&*format!("Usage: {} [options]", program)));
-        std::process::exit(0);
-    }
-    if opt_matches.opt_present("V") {
-        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-        std::process::exit(0);
-    }
-
-    if let Some(target_arch) = opt_matches.opt_str("a") {
-        build_target.arch = Some(target_arch);
-    }
-    let target_path = opt_matches.opt_str("o").map(PathBuf::from);
-    let package = opt_matches.opt_str("p");
-    let auto_req_mode = AutoReqMode::try_from(
-        opt_matches
-            .opt_str("auto-req")
-            .unwrap_or("auto".to_string()),
-    )?;
-    if let Some(target) = opt_matches.opt_str("target") {
-        build_target.target = Some(target);
-    }
-    if let Some(target_dir) = opt_matches.opt_str("target-dir") {
-        build_target.target_dir = Some(target_dir);
-    }
-    if let Some(profile) = opt_matches.opt_str("profile") {
-        build_target.profile = Some(profile);
-    }
-    let payload_compress = opt_matches
-        .opt_str("payload-compress")
-        .unwrap_or("zstd".to_string());
-    let metadata_overwrite = opt_matches.opt_strs_pos("metadata-overwrite");
-    let set_metadata = opt_matches.opt_strs_pos("set-metadata");
-    let variant = opt_matches.opt_strs_pos("variant");
-
-    let mut extra_metadata = metadata_overwrite
-        .iter()
-        .map(|(i, v)| {
-            let (file, branch) = match v.split_once("#") {
-                None => (PathBuf::from(v), None),
-                Some((file, branch)) => (PathBuf::from(file), Some(branch.to_string())),
-            };
-            (*i, ExtraMetadataSource::File(file, branch))
-        })
-        .chain(
-            set_metadata
-                .iter()
-                .map(|(i, v)| (*i, ExtraMetadataSource::Text(v.to_string()))),
-        )
-        .chain(variant.iter().map(|(i, v)| {
-            let file = Config::create_cargo_toml_path(package.as_ref().unwrap_or(&"".to_string()));
-            let branch = String::from("package.metadata.generate-rpm.variants.") + v;
-            (*i, ExtraMetadataSource::File(file, Some(branch)))
-        }))
-        .collect::<Vec<_>>();
-    extra_metadata.sort_by_key(|(i, _)| *i);
-    let extra_metadata = extra_metadata.iter().map(|(_, v)| v).cloned().collect();
-    Ok((
-        build_target,
-        target_path,
-        package,
-        CliSetting {
-            auto_req_mode,
-            payload_compress,
-            extra_metadata,
-        },
-    ))
-}
-
-fn main() {
-    (|| -> Result<(), Error> {
-        let (build_target, target_file, package, setting) = parse_arg()?;
-        process(&build_target, target_file, package, setting)?;
-        Ok(())
-    })()
-    .unwrap_or_else(|err| {
-        let program = env::args().nth(0).unwrap();
-        eprintln!("{}: {}", program, err);
-        if cfg!(debug_assertions) {
-            panic!("{:?}", err);
-        }
-        std::process::exit(1);
-    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::{build_target::BuildTarget, config::RpmBuilderConfig};
+use crate::{build_target::BuildTarget, config::BuilderConfig};
 use clap::Parser;
 use cli::{CargoWrapper, Cli};
 use std::{
@@ -61,7 +61,7 @@ fn main() -> Result<(), Error> {
         Config::new(Path::new(""), None, &extra_metadata)?
     };
     let rpm_pkg = config
-        .create_rpm_builder(RpmBuilderConfig::new(&build_target, &args))?
+        .create_rpm_builder(BuilderConfig::new(&build_target, &args))?
         .build()?;
 
     let pkg_name = rpm_pkg.metadata.get_name()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,7 @@ fn collect_metadata(args: &Cli) -> Vec<config::ExtraMetadataSource> {
 
 fn main() -> Result<(), Error> {
     let mut args = std::env::args();
-    let args = if let [Some("cargo"), Some("generate-rpm")] =
-        [args.next().as_deref(), args.next().as_deref()]
-    {
+    let args = if let Some("generate-rpm") = args.nth(1).as_deref() {
         let CargoWrapper::GenerateRpm(args) = CargoWrapper::parse();
         args
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,6 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-
 fn main() {
     if let Err(err) = run() {
         eprintln!("{err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crate::{build_target::BuildTarget, config::RpmBuilderConfig};
 use clap::Parser;
-use cli::Commands;
+use cli::{CargoWrapper, Cli};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -15,7 +15,7 @@ mod error;
 use config::{Config, ExtraMetadataSource};
 use error::Error;
 
-fn collect_metadata(args: &cli::Args) -> Vec<config::ExtraMetadataSource> {
+fn collect_metadata(args: &Cli) -> Vec<config::ExtraMetadataSource> {
     args.metadata_overwrite
         .iter()
         .map(|v| {
@@ -42,7 +42,15 @@ fn collect_metadata(args: &cli::Args) -> Vec<config::ExtraMetadataSource> {
 }
 
 fn main() -> Result<(), Error> {
-    let Commands::GenerateRpm(args) = cli::Cli::parse().command;
+    let mut args = std::env::args();
+    let args = if let [Some("cargo"), Some("generate-rpm")] =
+        [args.next().as_deref(), args.next().as_deref()]
+    {
+        let CargoWrapper::GenerateRpm(args) = CargoWrapper::parse();
+        args
+    } else {
+        Cli::parse()
+    };
 
     let build_target = BuildTarget::new(&args);
     let extra_metadata = collect_metadata(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn collect_metadata(args: &Cli) -> Vec<config::ExtraMetadataSource> {
         .collect::<Vec<_>>()
 }
 
-fn main() -> Result<(), Error> {
+fn run() -> Result<(), Error> {
     let mut args = std::env::args();
     let args = if let Some("generate-rpm") = args.nth(1).as_deref() {
         let CargoWrapper::GenerateRpm(args) = CargoWrapper::parse();
@@ -93,4 +93,12 @@ fn main() -> Result<(), Error> {
     rpm_pkg.write(&mut f)?;
 
     Ok(())
+}
+
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
While `clap`-based code is somewhat heavier than `getopts`, it's more powerful and results in cleaner and easier to maintain code.

This PR also fixes a bunch of Clippy warnings and introduces the `source-date` flag necessary for reproducible builds.

I am not completely sure I got the extra metadata stuff correctly, so it's better to double check it.

Closes #82