### PR TITLE
upgrade rpm crates (v0.11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = "0.11.0"
+rpm = { version = "0.11.0", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3.0"
-rpm = "0.9.0-alpha.1"
+rpm = "0.11.0"
 toml = "0.7"
 cargo_toml = "0.15"
 getopts = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,18 @@ pub enum ConfigError {
 }
 
 #[derive(thiserror::Error, Debug)]
+pub struct FileAnnotatedError<E: StdError + Display>(pub Option<PathBuf>, #[source] pub E);
+
+impl<E: StdError + Display> Display for FileAnnotatedError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            None => Display::fmt(&self.1, f),
+            Some(path) => write!(f, "{}: {}", path.as_path().display(), self.1),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum AutoReqError {
     #[error("Wrong auto-req mode")]
     WrongMode,
@@ -54,15 +66,9 @@ pub enum AutoReqError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub struct FileAnnotatedError<E: StdError + Display>(pub Option<PathBuf>, #[source] pub E);
-
-impl<E: StdError + Display> Display for FileAnnotatedError<E> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            None => Display::fmt(&self.1, f),
-            Some(path) => write!(f, "{}: {}", path.as_path().display(), self.1),
-        }
-    }
+pub enum PayloadCompressError {
+    #[error("Unsupported payload compress type: {0}")]
+    UnsupportedType(String),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -79,6 +85,8 @@ pub enum Error {
     AutoReq(#[from] AutoReqError),
     #[error(transparent)]
     Rpm(#[from] RPMError),
+    #[error(transparent)]
+    PayloadCompress(#[from] PayloadCompressError),
     #[error("{1}: {0}")]
     FileIo(PathBuf, #[source] IoError),
     #[error(transparent)]


### PR DESCRIPTION
upgrade to rpm crates and removing pgp dependency.

Rework of #75, which was reverted in #76. This PR take into account of breaking change of rpm-rs crate mentioned by @dralley in https://github.com/cat-in-136/cargo-generate-rpm/commit/dc6b4c6ee3940d8b4b8d8df75b7530c10b0fb671#r114846727.

This PR also remove pgp dependency. Because it is not used by cargo-generate-rpm as of now. This also resolve #84.