### PR TITLE
Output directory now used by target_file_name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,7 @@ fn run() -> Result<(), Error> {
         .unwrap_or_default();
     let file_name = format!("{pkg_name}-{pkg_version}{pkg_release}{pkg_arch}.rpm");
 
-    let target_file_name = match args.output.map(PathBuf::from) {
-        Some(path) if path.is_dir() => path.join(file_name),
-        Some(path) => path,
-        None => build_target.target_path("generate-rpm").join(file_name),
-    };
+    let target_file_name = determine_output_dir(args.output.as_ref(), &file_name, build_target);
 
     if let Some(parent_dir) = target_file_name.parent() {
         if !parent_dir.exists() {
@@ -95,9 +91,68 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
+fn determine_output_dir(
+    output: Option<&PathBuf>,
+    file_name: &String,
+    build_target: BuildTarget,
+) -> PathBuf {
+    match output.as_ref().map(PathBuf::from) {
+        Some(path) if path.is_dir() => path.join(file_name),
+        Some(path) => path,
+        None => build_target.target_path("generate-rpm").join(file_name),
+    }
+}
+
 fn main() {
     if let Err(err) = run() {
         eprintln!("{err}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Test the three cases of determining the output file name:
+    // 1. Output is a directory
+    // 2. Output is a file
+    // 3. Output is not specified
+    #[test]
+    fn test_ouput_is_dir() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let pathbufbinding = &tempdir.path().to_path_buf();
+
+        let output = Some(pathbufbinding);
+        let file_name = String::from("test.rpm");
+        let build_target = BuildTarget::new(&crate::cli::Cli::default());
+
+        let target_file_name = determine_output_dir(output, &file_name, build_target);
+        assert_eq!(target_file_name, tempdir.path().join("test.rpm"));
+    }
+    #[test]
+    fn test_ouput_is_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let pathbufbinding = &tempdir.path().to_path_buf();
+        let temppath = pathbufbinding.join("foo.rpm");
+
+        let output = Some(&temppath);
+        let file_name = String::from("test.rpm");
+        let build_target = BuildTarget::new(&crate::cli::Cli::default());
+
+        let target_file_name = determine_output_dir(output, &file_name, build_target);
+        assert_eq!(target_file_name, temppath);
+    }
+
+    #[test]
+    fn test_no_output_specified() {
+        let output = None;
+        let file_name = String::from("test.rpm");
+        let build_target = BuildTarget::new(&crate::cli::Cli::default());
+
+        let target_file_name = determine_output_dir(output, &file_name, build_target);
+        assert_eq!(
+            target_file_name,
+            PathBuf::from("target/generate-rpm/test.rpm")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn run() -> Result<(), Error> {
         .unwrap_or_default();
     let file_name = format!("{pkg_name}-{pkg_version}{pkg_release}{pkg_arch}.rpm");
 
-    let target_file_name = match args.target.map(PathBuf::from) {
+    let target_file_name = match args.output.map(PathBuf::from) {
         Some(path) if path.is_dir() => path.join(file_name),
         Some(path) => path,
         None => build_target.target_path("generate-rpm").join(file_name),


### PR DESCRIPTION
Fixup bug from clap migration where the target file name was determined using the `target` argument and the docs indicate that it should be determined using the `output` argument. 