### PR TITLE
add alias to auto_req for disabled option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,9 +126,9 @@ impl ValueEnum for AutoReqMode {
         use AutoReqMode::*;
 
         let val = match self {
-            Disabled => {
-                PossibleValue::new("disabled").help("Disable automatic discovery of dependencies")
-            }
+            Disabled => PossibleValue::new("disabled")
+                .help("Disable automatic discovery of dependencies")
+                .alias("no"),
             Builtin => {
                 PossibleValue::new("builtin").help("Use the builtin procedure based on ldd.")
             }


### PR DESCRIPTION
Adding a  `no` alias to auto-req for the `disabled` option to reverse a regression made as part of #82 see #101 for details.

```
> #before 
> cargo run --release -- --auto-req no
error: invalid value 'no' for '--auto-req <AUTO_REQ>'
  [possible values: disabled, builtin, find-requires, /path/to/find-requires]

For more information, try '--help'.

> #after
> cargo run --release -- --auto-req no
>
```