### PR TITLE
add support for config noreplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ from [the `Cargo.toml` file](https://doc.rust-lang.org/cargo/reference/manifest.
       If source contains wildcard character `*`, it must be a directory, not a file path.
     * mode: the permissions as octal string. (e.g. `755` to indicate `-rwxr-xr-x`)
     * config: set true if it is a configuration file.
+      Set the string `"noreplace"` instead to avoid overwriting an existing file that have been modified.
+      (Not supported for `"missingok"` as of now)
     * doc: set true if it is a document file.
     * user: the owner of the file.
     * group: the group owner of the file.


### PR DESCRIPTION
introduce `config = "noreplace"` to file information so that the file is not be replaced on the installation as like `%config(noreplaced)` specified in the RPM spec file.

to close #88.