### PR TITLE
Fix degrades of `--auto-req` caused by clap migration (#83)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rpm = { version = "0.13.1", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
 clap = { version = "4.3", features = ["derive"] }
+color-print = "0.3"
 thiserror = "1"
 elf = "0.7"
 

--- a/README.md
+++ b/README.md
@@ -131,17 +131,17 @@ It is necessary to place a space between version and symbols such as `<`, `<=`, 
 
 This command automatically determines what shared libraries a package requires.
 There may be times when the automatic dependency processing is not desired.
-In this case, the package author may set `package.metadata.generate-rpm.auto-req` to `"no"` or
-the user who executes this command may specify command line option `--auto-req no`.
+The packege author and users can configure the processing.
 
-* `--auto-req auto`: The following rules are used to determine the preferred automatic dependency process:
+* `--auto-req auto` or `--auto-req` not specified: Use the preferred automatic dependency process.
+  The following rules are used:
     * If `package.metadata.generate-rpm.auto-req` set to `"no"` or `"disabled"`, the process is disabled.
-    * If `/usr/lib/rpm/find-requires` exists, it is used (same behaviour as `--auto-req /usr/lib/rpm/find-requires`).
+    * If `/usr/lib/rpm/find-requires` exists, it is used (same behaviour as `--auto-req find-requires`).
     * Otherwise, builtin procedure is used (same behaviour as `--auto-req builtin`).
-* `--auto-req builtin`: the builtin procedure using `ldd` is used.
-* `--auto-req /path/to/find-requires`: the specified external program is used. This behavior is the same as the
-  original `rpmbuild`.
-* `--auto-req no`: the process is disabled.
+* `--auto-req disabled`, `--auto-req no`: Disable the discovery of dependencies.
+* `--auto-req builtin`: Use the builtin procedure based on `ldd`.
+* `--auto-req find-requires`: Use `/usr/lib/rpm/find-requires`. This behavior is the same as the original `rpmbuild`.
+* `--auto-req /path/to/find-requires`: Use the specified external program is used.
 
 `/bin/sh` is always added to the package requirements. To disable it, set `package.metadata.generate-rpm.require-sh`
 to `false`. You should not do this if you use scripts such as `pre_install_script` or if your assets contain shell

--- a/src/auto_req/mod.rs
+++ b/src/auto_req/mod.rs
@@ -19,17 +19,14 @@ pub enum AutoReqMode {
     BuiltIn,
 }
 
-impl From<&Option<cli::AutoReqMode>> for AutoReqMode {
-    fn from(value: &Option<cli::AutoReqMode>) -> Self {
-        use cli::AutoReqMode as M;
-        use AutoReqMode::*;
-
+impl From<cli::AutoReqMode> for AutoReqMode {
+    fn from(value: cli::AutoReqMode) -> Self {
         match value {
-            None => Auto,
-            Some(M::Disabled) => Disabled,
-            Some(M::Builtin) => BuiltIn,
-            Some(M::Script(path)) => Script(path.into()),
-            Some(M::FindRequires) => Script(PathBuf::from(RPM_FIND_REQUIRES)),
+            cli::AutoReqMode::Auto => AutoReqMode::Auto,
+            cli::AutoReqMode::Disabled => AutoReqMode::Disabled,
+            cli::AutoReqMode::Builtin => AutoReqMode::BuiltIn,
+            cli::AutoReqMode::FindRequires => AutoReqMode::Script(PathBuf::from(RPM_FIND_REQUIRES)),
+            cli::AutoReqMode::Script(path) => AutoReqMode::Script(path),
         }
     }
 }

--- a/src/auto_req/mod.rs
+++ b/src/auto_req/mod.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 mod builtin;
 mod script;
 
+/// The path to the system default find-requires program
 const RPM_FIND_REQUIRES: &str = "/usr/lib/rpm/find-requires";
 
 /// The method to auto-req

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,19 +33,17 @@ pub struct Cli {
     pub package: Option<String>,
 
     /// Automatic dependency processing mode.
-    #[arg(long,
+    #[arg(long, default_value = "auto",
         help = "Automatic dependency processing mode. \
-        [default: auto] \
         [possible values: auto, disabled, builtin, find-requires, /path/to/find-requires]",
         long_help = color_print::cstr!("Automatic dependency processing mode.\n\n\
-        [default: auto]\n\
         Possible values:\n\
-        - <bold>auto</bold>:                   Automatic discovery of dependencies.\n\
-        - <bold>disabled</bold>:               Disable automatic discovery of dependencies. [alias: no]\n\
+        - <bold>auto</bold>:                   Use the preferred automatic dependency process.\n\
+        - <bold>disabled</bold>:               Disable the discovery of dependencies. [alias: no]\n\
         - <bold>builtin</bold>:                Use the builtin procedure based on ldd.\n\
-        - <bold>find-requires</bold>:          Use the external program specified in RPM_FIND_REQUIRES.\n\
+        - <bold>find-requires</bold>:          Use /usr/lib/rpm/find-requires.\n\
         - <bold>/path/to/find-requires</bold>: Use the specified external program."))]
-    pub auto_req: Option<AutoReqMode>,
+    pub auto_req: AutoReqMode,
 
     /// Sub-directory name for all generated artifacts. May be
     /// specified with CARGO_BUILD_TARGET environment
@@ -214,18 +212,18 @@ mod tests {
     #[test]
     fn test_auto_req() {
         let args = Cli::try_parse_from([""]).unwrap();
-        assert_eq!(args.auto_req, None);
+        assert_eq!(args.auto_req, AutoReqMode::Auto);
         let args = Cli::try_parse_from(["", "--auto-req", "auto"]).unwrap();
-        assert_eq!(args.auto_req, Some(AutoReqMode::Auto));
+        assert_eq!(args.auto_req, AutoReqMode::Auto);
         let args = Cli::try_parse_from(["", "--auto-req", "builtin"]).unwrap();
-        assert_eq!(args.auto_req, Some(AutoReqMode::Builtin));
+        assert_eq!(args.auto_req, AutoReqMode::Builtin);
         let args = Cli::try_parse_from(["", "--auto-req", "find-requires"]).unwrap();
-        assert_eq!(args.auto_req, Some(AutoReqMode::FindRequires));
+        assert_eq!(args.auto_req, AutoReqMode::FindRequires);
         let args = Cli::try_parse_from(["", "--auto-req", "/usr/lib/rpm/find-requires"]).unwrap();
         assert!(
-            matches!(args.auto_req, Some(AutoReqMode::Script(v)) if v == PathBuf::from("/usr/lib/rpm/find-requires"))
+            matches!(args.auto_req, AutoReqMode::Script(v) if v == PathBuf::from("/usr/lib/rpm/find-requires"))
         );
         let args = Cli::try_parse_from(["", "--auto-req", "no"]).unwrap();
-        assert_eq!(args.auto_req, Some(AutoReqMode::Disabled));
+        assert_eq!(args.auto_req, AutoReqMode::Disabled);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,4 +161,50 @@ mod tests {
         use clap::CommandFactory;
         Cli::command().debug_assert()
     }
+
+    #[test]
+    fn test_metadata_overwrite() {
+        let args = Cli::try_parse_from([
+            "",
+            "--metadata-overwrite",
+            "TOML_FILE.toml",
+            "--metadata-overwrite",
+            "TOML_FILE.toml#TOML.PATH",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.metadata_overwrite,
+            vec!["TOML_FILE.toml", "TOML_FILE.toml#TOML.PATH"]
+        );
+    }
+
+    #[test]
+    fn test_set_metadata() {
+        let args = Cli::try_parse_from([
+            "",
+            "-s",
+            "toml \"text1\"",
+            "--set-metadata",
+            "toml \"text2\"",
+        ])
+        .unwrap();
+        assert_eq!(
+            args.set_metadata,
+            vec!["TOML_FILE.toml", "TOML_FILE.toml#TOML.PATH"]
+        );
+    }
+
+    #[test]
+    fn test_auto_req() {
+        //let args = Cli::try_parse_from(["", "--auto-req", "auto"]).unwrap();
+        //assert!(matches!(args.auto_req, Some(AutoReqMode::Auto)));
+        let args = Cli::try_parse_from(["", "--auto-req", "builtin"]).unwrap();
+        assert!(matches!(args.auto_req, Some(AutoReqMode::Builtin)));
+        let args = Cli::try_parse_from(["", "--auto-req", "find-requires"]).unwrap();
+        assert!(matches!(args.auto_req, Some(AutoReqMode::FindRequires)));
+        //let args = Cli::try_parse_from(["", "--auto-req", "/usr/lib/rpm/find-requires"]).unwrap();
+        //assert!(matches!(args.auto_req, Some(AutoReqMode::Script(v)) if v.eq("/usr/lib/rpm/find-requires")));
+        let args = Cli::try_parse_from(["", "--auto-req", "no"]).unwrap();
+        assert!(matches!(args.auto_req, Some(AutoReqMode::Disabled)));
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,3 +152,13 @@ impl ValueEnum for AutoReqMode {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        Cli::command().debug_assert()
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -302,9 +302,8 @@ impl Config {
 
         let meta_aut_req = metadata.get_str("auto-req")?;
         let auto_req = match (&cfg.args.auto_req, meta_aut_req) {
-            (None, Some("no" | "disabled")) => AutoReqMode::Disabled,
-            (None, _) => AutoReqMode::Auto,
-            (Some(v), _) => AutoReqMode::from(v.clone()),
+            (crate::cli::AutoReqMode::Auto, Some("no" | "disabled")) => AutoReqMode::Disabled,
+            (v, _) => AutoReqMode::from(v.clone()),
         };
 
         for requires in find_requires(expanded_file_paths, auto_req)? {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -303,7 +303,8 @@ impl Config {
         let meta_aut_req = metadata.get_str("auto-req")?;
         let auto_req = match (&cfg.args.auto_req, meta_aut_req) {
             (None, Some("no" | "disabled")) => AutoReqMode::Disabled,
-            (r, _) => r.into(),
+            (None, _) => AutoReqMode::Auto,
+            (Some(v), _) => AutoReqMode::from(v.clone()),
         };
 
         for requires in find_requires(expanded_file_paths, auto_req)? {


### PR DESCRIPTION
Fix the following issues caused by clap migration (#83)
- `--auto-req auto` does not work
- `--auto-req /path/to/find-requires` does not work (fix #107)

This PR also contains:
- Add `disabled` description to README.md
- Add `find-requires` description to README.md
- Add some test codes