### PR TITLE
fix metadata overwrite option behaviour due to clap degression

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,12 @@ scripts.
 `[package.metadata.generate-rpm]` can be overwritten. The following command line options are used:
 
 * `--metadata-overwrite=TOML_FILE.toml` : Overwrite the `[package.metadata.generate-rpm]` options with the contents of
-  the specified TOML file.
+  the specified TOML file. Multiple files can be specified, separated by commas.
 * `--metadata-overwrite=TOML_FILE.toml#TOML.PATH` : Overwrites the `[package.metadata.generate-rpm]` options with the
   table specified in the TOML path of the TOML file.
   Only a sequence of bare keys connected by dots is acceptable for the TOML path.
   Path containing quoted keys (such as `metadata."παραλλαγή"`) cannot be acceptable.
+  Multiple files with TOML pathes can be specified, separated by commas.
 * `-s 'toml "text"'` or `--set-metadata='toml "text"'` : Overwrite the `[package.metadata.generate-rpm]` options with
   inline TOML text.
   The argument text --- inline TOML text must be enclosed in quotation marks since it contains spaces.
@@ -165,10 +166,11 @@ scripts.
   It is a shortcut to `--metadata-overwrite=path/to/Cargo.toml#package.metadata.generate-rpm.variants.VARIANT`.
   It is intended for providing multiple variants of the metadata in a Cargo.toml and ability for the users to select the
   variant using --variant=name option.
+  Multiple variant names can be specified, separated by commas.
 
-These options can be specified more than once, with the last written one specified being applied.
-For example, the arguments -s 'release = "alpha"' `--metadata-overwrite=beta.toml` where beta.toml
-contains `release = "beta"` gives `release = "beta"`.
+These options may be specified multiple times, with the last one written being applied regardless of the kind of option.
+For example, the arguments `-s 'release = "alpha"' --metadata-overwrite=beta.toml` where beta.toml
+contains `release = "beta"`, then gives `release = "beta"`.
 
 ## Advanced Usage
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,7 +80,7 @@ pub struct Cli {
     pub metadata_overwrite: Vec<String>,
 
     /// Overwrite metadata with TOML text.
-    #[arg(short, long, value_delimiter = ',')]
+    #[arg(short, long)]
     pub set_metadata: Vec<String>,
 
     /// Shortcut to --metadata-overwrite=path/to/Cargo.toml#package.metadata.generate-rpm.variants.VARIANT

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{
     builder::{PathBufValueParser, PossibleValuesParser, TypedValueParser, ValueParserFactory},
     Arg, ArgMatches, Command, CommandFactory, FromArgMatches, Parser, ValueEnum,
 };
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
 /// Wrapper used when the application is executed as Cargo plugin
@@ -89,16 +89,59 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn get_matches_and_try_parse() -> Result<(Self, ArgMatches), clap::Error> {
-        let mut args = std::env::args();
-        let mut matches = if let Some("generate-rpm") = args.nth(1).as_deref() {
-            <CargoWrapper as CommandFactory>::command().get_matches()
+    #[inline]
+    fn get_matches_and_try_parse_from<F, I, T>(
+        args_fn: F,
+    ) -> Result<(Self, ArgMatches), clap::Error>
+    where
+        F: Fn() -> I,
+        I: IntoIterator<Item = T> + Iterator<Item = OsString>,
+        T: Into<OsString> + Clone,
+    {
+        let mut args = args_fn();
+        let matches = if args.nth(1) == Some(OsString::from("generate-rpm")) {
+            let args = args_fn();
+            <CargoWrapper as CommandFactory>::command().get_matches_from(args)
         } else {
-            <Self as CommandFactory>::command().get_matches()
+            let args = args_fn();
+            <Self as CommandFactory>::command().get_matches_from(args)
         };
-        let arg = Self::from_arg_matches_mut(&mut matches)?;
+        let arg = Self::from_arg_matches_mut(&mut matches.clone())?;
 
         Ok((arg, matches))
+    }
+
+    pub fn get_matches_and_try_parse() -> Result<(Self, ArgMatches), clap::Error> {
+        Self::get_matches_and_try_parse_from(&std::env::args_os)
+    }
+
+    pub fn extra_metadata(&self, matches: &ArgMatches) -> Vec<ExtraMetadataSource> {
+        let mut extra_metadata_args = Vec::new();
+
+        if let Some(indices) = matches.indices_of("metadata_overwrite") {
+            for (v, i) in self.metadata_overwrite.iter().zip(indices) {
+                let (file, branch) = match v.split_once('#') {
+                    None => (PathBuf::from(v), None),
+                    Some((file, branch)) => (PathBuf::from(file), Some(branch.to_string())),
+                };
+                extra_metadata_args.push((i, ExtraMetadataSource::File(file, branch)));
+            }
+        }
+
+        if let Some(indices) = matches.indices_of("set_metadata") {
+            for (v, i) in self.set_metadata.iter().zip(indices) {
+                extra_metadata_args.push((i, ExtraMetadataSource::Text(v.to_string())));
+            }
+        }
+
+        if let Some(indices) = matches.indices_of("variant") {
+            for (v, i) in self.variant.iter().zip(indices) {
+                extra_metadata_args.push((i, ExtraMetadataSource::Variant(v.to_string())));
+            }
+        }
+
+        extra_metadata_args.sort_by_key(|v| v.0);
+        extra_metadata_args.drain(..).map(|v| v.1).collect()
     }
 }
 
@@ -185,6 +228,13 @@ impl TypedValueParser for AutoReqModeParser {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExtraMetadataSource {
+    File(PathBuf, Option<String>),
+    Text(String),
+    Variant(String),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,6 +246,31 @@ mod tests {
     #[test]
     fn verify_cargo_wrapper() {
         <CargoWrapper as CommandFactory>::command().debug_assert()
+    }
+
+    #[test]
+    fn test_get_matches_and_try_parse_from() {
+        let (args, matcher) = Cli::get_matches_and_try_parse_from(|| {
+            ["", "-o", "/dev/null"].map(&OsString::from).into_iter()
+        })
+        .unwrap();
+        assert_eq!(args.output, Some(PathBuf::from("/dev/null")));
+        assert_eq!(
+            matcher.indices_of("output").unwrap().collect::<Vec<_>>(),
+            &[2]
+        );
+
+        let (args, matcher) = Cli::get_matches_and_try_parse_from(|| {
+            ["generate-rpm", "-o", "/dev/null"]
+                .map(&OsString::from)
+                .into_iter()
+        })
+        .unwrap();
+        assert_eq!(args.output, Some(PathBuf::from("/dev/null")));
+        assert_eq!(
+            matcher.indices_of("output").unwrap().collect::<Vec<_>>(),
+            &[2]
+        );
     }
 
     #[test]
@@ -225,6 +300,51 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(args.set_metadata, vec!["toml \"text1\"", "toml \"text2\""]);
+    }
+
+    #[test]
+    fn test_extrametadata() {
+        let (args, matches) = Cli::get_matches_and_try_parse_from(|| {
+            [
+                "",
+                "--metadata-overwrite",
+                "TOML_FILE1.toml",
+                "-s",
+                "toml \"text1\"",
+                "--metadata-overwrite",
+                "TOML_FILE2.toml#TOML.PATH",
+                "--variant",
+                "VARIANT1,VARIANT2",
+                "--set-metadata",
+                "toml \"text2\"",
+                "--metadata-overwrite",
+                "TOML_FILE3.toml#TOML.PATH,TOML_FILE4.toml",
+            ]
+            .map(&OsString::from)
+            .into_iter()
+        })
+        .unwrap();
+
+        let metadata = args.extra_metadata(&matches);
+        assert_eq!(
+            metadata,
+            vec![
+                ExtraMetadataSource::File(PathBuf::from("TOML_FILE1.toml"), None),
+                ExtraMetadataSource::Text(String::from("toml \"text1\"")),
+                ExtraMetadataSource::File(
+                    PathBuf::from("TOML_FILE2.toml"),
+                    Some(String::from("TOML.PATH"))
+                ),
+                ExtraMetadataSource::Variant(String::from("VARIANT1")),
+                ExtraMetadataSource::Variant(String::from("VARIANT2")),
+                ExtraMetadataSource::Text(String::from("toml \"text2\"")),
+                ExtraMetadataSource::File(
+                    PathBuf::from("TOML_FILE3.toml"),
+                    Some(String::from("TOML.PATH"))
+                ),
+                ExtraMetadataSource::File(PathBuf::from("TOML_FILE4.toml"), None),
+            ]
+        );
     }
 
     #[test]

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -1,5 +1,6 @@
+use crate::cli::ExtraMetadataSource;
 use crate::error::{ConfigError, FileAnnotatedError};
-use crate::{Error, ExtraMetadataSource};
+use crate::Error;
 use cargo_toml::Manifest;
 use rpm::Scriptlet;
 use std::fs;
@@ -131,6 +132,7 @@ impl ExtraMetaData {
                     .map_err(|e| FileAnnotatedError(annot, e))?;
                 Ok(Self(table.clone(), source.clone()))
             }
+            ExtraMetadataSource::Variant(_) => todo!(),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,19 +7,13 @@ use toml::value::Table;
 
 use crate::auto_req::{find_requires, AutoReqMode};
 use crate::build_target::BuildTarget;
-use crate::cli::Cli;
+use crate::cli::{Cli, ExtraMetadataSource};
 use crate::error::{ConfigError, Error};
 use file_info::FileInfo;
 use metadata::{CompoundMetadataConfig, ExtraMetaData, MetadataConfig, TomlValueHelper};
 
 mod file_info;
 mod metadata;
-
-#[derive(Debug, Clone)]
-pub enum ExtraMetadataSource {
-    File(PathBuf, Option<String>),
-    Text(String),
-}
 
 #[derive(Debug)]
 pub struct BuilderConfig<'a> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,7 +38,7 @@ impl Config {
     pub fn new(
         project_base_path: &Path,
         workspace_base_path: Option<&Path>,
-        extra_metadata: &[ExtraMetadataSource],
+        extra_metadata_src: &[ExtraMetadataSource],
     ) -> Result<Self, Error> {
         let manifest_path = Self::create_cargo_toml_path(project_base_path);
 
@@ -72,9 +72,9 @@ impl Config {
             })?
         };
 
-        let extra_metadata = extra_metadata
+        let extra_metadata = extra_metadata_src
             .iter()
-            .map(ExtraMetaData::new)
+            .map(|v| ExtraMetaData::new(v, &manifest_path))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,34 +11,8 @@ mod cli;
 mod config;
 mod error;
 
-use config::{Config, ExtraMetadataSource};
+use config::Config;
 use error::Error;
-
-fn collect_metadata(args: &Cli) -> Vec<config::ExtraMetadataSource> {
-    args.metadata_overwrite
-        .iter()
-        .map(|v| {
-            let (file, branch) = match v.split_once('#') {
-                None => (PathBuf::from(v), None),
-                Some((file, branch)) => (PathBuf::from(file), Some(branch.to_string())),
-            };
-            ExtraMetadataSource::File(file, branch)
-        })
-        .chain(
-            args.set_metadata
-                .iter()
-                .map(|v| ExtraMetadataSource::Text(v.to_string())),
-        )
-        .chain(args.variant.iter().map(|v| {
-            let file = match &args.package {
-                Some(package) => Config::create_cargo_toml_path(package),
-                None => Config::create_cargo_toml_path(""),
-            };
-            let branch = String::from("package.metadata.generate-rpm.variants.") + v;
-            ExtraMetadataSource::File(file, Some(branch))
-        }))
-        .collect::<Vec<_>>()
-}
 
 fn determine_output_dir(
     output: Option<&PathBuf>,
@@ -53,10 +27,10 @@ fn determine_output_dir(
 }
 
 fn run() -> Result<(), Error> {
-    let (args, matcher) = Cli::get_matches_and_try_parse().unwrap_or_else(|e| e.exit());
+    let (args, matches) = Cli::get_matches_and_try_parse().unwrap_or_else(|e| e.exit());
 
     let build_target = BuildTarget::new(&args);
-    let extra_metadata = collect_metadata(&args);
+    let extra_metadata = args.extra_metadata(&matches);
 
     let config = if let Some(p) = &args.package {
         Config::new(Path::new(p), Some(Path::new("")), &extra_metadata)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use crate::{build_target::BuildTarget, config::BuilderConfig};
-use clap::Parser;
-use cli::{CargoWrapper, Cli};
+use cli::Cli;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -54,13 +53,7 @@ fn determine_output_dir(
 }
 
 fn run() -> Result<(), Error> {
-    let mut args = std::env::args();
-    let args = if let Some("generate-rpm") = args.nth(1).as_deref() {
-        let CargoWrapper::GenerateRpm(args) = CargoWrapper::parse();
-        args
-    } else {
-        Cli::parse()
-    };
+    let (args, matcher) = Cli::get_matches_and_try_parse().unwrap_or_else(|e| e.exit());
 
     let build_target = BuildTarget::new(&args);
     let extra_metadata = collect_metadata(&args);


### PR DESCRIPTION
to fix #109

* take consideration into the argument order among --metadata-overwrite, --set-metadata(-s) and --variant
* remove value_delimiter = ',' from  --set-metadata(-s) so that it can handle array and hash
* add some test codes
* update README.md