### PR TITLE
Upgrade crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.14.1"
 edition = "2021"
 
 [dependencies]
-glob = "0.3.0"
-rpm = { version = "0.13.1", default-features = false }
+glob = "0.3"
+rpm = { version = "0.14", default-features = false }
 toml = "0.7"
 cargo_toml = "0.15"
-clap = { version = "4.3", features = ["derive"] }
+clap = { version = "~4.3", features = ["derive"] }
 color-print = "0.3"
 thiserror = "1"
 elf = "0.7"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ using the [`rpm`](https://crates.io/crates/rpm) crate.
 ![Rust](https://github.com/cat-in-136/cargo-generate-rpm/workflows/Rust/badge.svg)
 [![cargo-generate-rpm at crates.io](https://img.shields.io/crates/v/cargo-generate-rpm.svg)](https://crates.io/crates/cargo-generate-rpm)
 
+Legacy systems requiring RPMv3 (e.g. CentOS 7) are no longer supported due to rpm-rs compatibility.
+Use versions prior to 0.15 for such a system.
+
 ## Install
 
 ```sh
@@ -221,9 +224,6 @@ Similarly, if using a custom build profile with, for example, `--profile custom`
 
 The default payload compress type of the generated RPM file is zstd.
 You can specify the payload compress type with `--payload-compress TYPE`: none, gzip, or zstd.
-
-For the legacy system (e.g. centos7), specify legacy compress type explicitly e.g. `--payload-compress none`.
-
 
 ### Scriptlet Flags and Prog Settings
 

--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -302,7 +302,7 @@ mod test {
 
     #[test]
     fn test_new() {
-        let manifest = Manifest::from_path("Cargo.toml").unwrap();
+        let manifest = Manifest::from_path("./Cargo.toml").unwrap();
         let metadata = manifest.package.unwrap().metadata.unwrap();
         let metadata = metadata
             .as_table()

--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -161,7 +161,7 @@ impl FileInfo<'_, '_, '_, '_, '_> {
             rpm_file_option = rpm_file_option.is_config();
         }
         if self.config_noreplace {
-            rpm_file_option = rpm_file_option.is_no_replace();
+            rpm_file_option = rpm_file_option.is_config_noreplace();
         }
         if self.doc {
             rpm_file_option = rpm_file_option.is_doc();


### PR DESCRIPTION
Upgrade dependency library versions. This includes upgrading to rpm-rs so that RPMv3 is no longer supported i.e., which is to close #106.