### PR TITLE
fix: doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Upon run `cargo generate-rpm` on your cargo project, a binary RPM package file w
 in `target/generate-rpm/XXX.rpm`.
 You can change the RPM package file location using `-o` option.
 
-In advance, run `cargo run --release` and strip the debug symbols (`strip -s target/release/XXX`), because these are not
+In advance, run `cargo build --release` and strip the debug symbols (`strip -s target/release/XXX`), because these are not
 run upon `cargo generate-rpm` as of now.
 
 ## Configuration


### PR DESCRIPTION
I suppose it's the `cargo build --release` to be executed before the `strip -s target/release/xxx` command.