### PR TITLE
fix: bump cargo_toml to 0.21 to fix #128 when building under Rust 202…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 glob = "0.3"
 rpm = { version = "0.14", default-features = false }
 toml = "0.7"
-cargo_toml = "0.15"
+cargo_toml = "0.21"
 clap = { version = "~4.3", features = ["derive"] }
 color-print = "0.3"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 glob = "0.3"
 rpm = { version = "0.14", default-features = false }
-toml = "0.7"
+toml = "0.8"
 cargo_toml = "0.21"
 clap = { version = "~4.3", features = ["derive"] }
 color-print = "0.3"


### PR DESCRIPTION
fixes #128 and support Rust 1.85 where 2024 edition released