### PR TITLE
Fix the UTF-8 encoding error (executable discovery logic)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ edition = "2021"
 
 [dependencies]
 glob = "0.3"
-rpm = { version = "0.17", default-features = false }
+rpm = { version = "0.17", default-features = false, features = [
+    "zstd-compression",
+    "gzip-compression",
+    "xz-compression",
+    "bzip2-compression",
+] }
 toml = "0.8"
 cargo_toml = "0.22"
 clap = { version = "~4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "cargo-generate-rpm"
 license = "MIT"
 authors = ["@cat_in_136"]
-categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools::build-utils"]
+categories = [
+    "command-line-utilities",
+    "development-tools::cargo-plugins",
+    "development-tools::build-utils",
+]
 description = "Generate a binary RPM package (.rpm) from Cargo projects"
 homepage = "https://github.com/cat-in-136/cargo-generate-rpm"
 readme = "README.md"
@@ -13,12 +17,12 @@ edition = "2021"
 
 [dependencies]
 glob = "0.3"
-rpm = { version = "0.14", default-features = false }
+rpm = { version = "0.17", default-features = false }
 toml = "0.8"
-cargo_toml = "0.21"
-clap = { version = "~4.3", features = ["derive"] }
+cargo_toml = "0.22"
+clap = { version = "~4.5", features = ["derive"] }
 color-print = "0.3"
-thiserror = "1"
+thiserror = "2"
 elf = "0.7"
 
 [dev-dependencies]
@@ -28,5 +32,5 @@ tempfile = "3"
 assets = [
     { source = "target/release/cargo-generate-rpm", dest = "/usr/bin/cargo-generate-rpm", mode = "0755" },
     { source = "LICENSE", dest = "/usr/share/doc/cargo-generate-rpm/LICENSE", doc = true, mode = "0644" },
-    { source = "README.md", dest = "/usr/share/doc/cargo-generate-rpm/README.md", doc = true, mode = "0644" }
+    { source = "README.md", dest = "/usr/share/doc/cargo-generate-rpm/README.md", doc = true, mode = "0644" },
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ pub struct Cli {
     /// modification time of included files and package build time.
     ///
     /// This value can also be provided using the SOURCE_DATE_EPOCH
-    /// enviroment variable.
+    /// environment variable.
     #[arg(long)]
     pub source_date: Option<u32>,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ impl<E: StdError + Display> Display for FileAnnotatedError<E> {
 pub enum AutoReqError {
     #[error("Failed to execute `{}`: {1}", .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
-    #[error(transparent)]
+    #[error("Failed to read file: {0}")]
     Io(#[from] IoError),
 }
 
@@ -68,21 +68,21 @@ pub enum AutoReqError {
 pub enum Error {
     #[error("Cargo.toml: {0}")]
     CargoToml(#[from] CargoTomlError),
-    #[error(transparent)]
+    #[error("Config: {0}")]
     Config(#[from] ConfigError),
-    #[error("Invalid value of enviroment variable {0}: {1}")]
+    #[error("Invalid value of environment variable {0}: {1}")]
     #[allow(clippy::enum_variant_names)] // Allow bad terminology for compatibility
     EnvError(&'static str, String),
-    #[error(transparent)]
+    #[error("Error parsing TOML file: {0}")]
     ParseTomlFile(#[from] FileAnnotatedError<TomlDeError>),
-    #[error(transparent)]
+    #[error("Error in extra config: {0}")]
     ExtraConfig(#[from] FileAnnotatedError<ConfigError>),
-    #[error(transparent)]
+    #[error("Error in auto-require: {0}")]
     AutoReq(#[from] AutoReqError),
-    #[error(transparent)]
+    #[error("Error parsing RPM file: {0}")]
     Rpm(#[from] rpm::Error),
     #[error("{1}: {0}")]
     FileIo(PathBuf, #[source] IoError),
-    #[error(transparent)]
+    #[error("I/O error: {0}")]
     Io(#[from] IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ impl<E: StdError + Display> Display for FileAnnotatedError<E> {
 
 #[derive(thiserror::Error, Debug)]
 pub enum AutoReqError {
-    #[error("Failed to execute `{}`: {1}", .0.clone().into_string().unwrap_or_default())]
+    #[error("Failed to execute `{file}`: {1}", file = .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
     #[error("Failed to read file: {0}")]
     Io(#[from] IoError),


### PR DESCRIPTION
The reason I forked this repo in the first place was to fix the UTF-8 encoding error. I was able to track down this error to the `find_require_of_shebang` function in `src/auto_req/builtin.rs`. On MacOS there is no `ldd` executable, so the `find_requires_of_elf` always fails. This causes the `find_requires` function to move on to treating the binary produced by cargo build as a script which produces the UTF-8 error.

To mitigate this problem, I modified the error message to be a bit more verbose, and I modified the `find_require_of_shebang` function to not fail on a UTF-8 error.

While I was in there, I also went ahead and upgraded all your dependencies and fixed some breaking changes caused by dependency issues.

I'm sorry I didn't take the time to find a more eloquent solution. If you'd like me to do some refactoring, let me know.

Dependency updates and improvements:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R30): Updated the `rpm` crate to version 0.17 and added several compression features. Updated versions for `cargo_toml`, `clap`, and `thiserror` crates.

Error handling improvements:

* [`src/auto_req/builtin.rs`](diffhunk://#diff-8f3576ecffdd111ecb7011eb5386abb6c114224ef5c5fbe4e95165877f8a27b3L133-R149): Improved error handling in the `find_require_of_shebang` function to return `Ok(None)` on file open and read errors.
* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL61-R86): Enhanced error messages for various error types in the `AutoReqError` and `Error` enums to provide more context.

Minor fixes:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R9): Reformatted the `categories` and `assets` sections for better readability. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R9) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L31-R40)
* [`src/cli.rs`](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL72-R72): Corrected a typo in the documentation comment for the `source_date` field.