### PR TITLE
Update crates and bump rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ edition = "2021"
 
 [dependencies]
 glob = "0.3"
-rpm = { version = "0.17", default-features = false }
+rpm = { version = "0.17", default-features = false, features = [
+    "zstd-compression",
+    "gzip-compression",
+    "xz-compression",
+    "bzip2-compression",
+] }
 toml = "0.8"
 cargo_toml = "0.22"
 clap = { version = "~4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,11 @@
 name = "cargo-generate-rpm"
 license = "MIT"
 authors = ["@cat_in_136"]
-categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools::build-utils"]
+categories = [
+    "command-line-utilities",
+    "development-tools::cargo-plugins",
+    "development-tools::build-utils",
+]
 description = "Generate a binary RPM package (.rpm) from Cargo projects"
 homepage = "https://github.com/cat-in-136/cargo-generate-rpm"
 readme = "README.md"
@@ -13,12 +17,12 @@ edition = "2021"
 
 [dependencies]
 glob = "0.3"
-rpm = { version = "0.14", default-features = false }
+rpm = { version = "0.17", default-features = false }
 toml = "0.8"
-cargo_toml = "0.21"
-clap = { version = "~4.3", features = ["derive"] }
+cargo_toml = "0.22"
+clap = { version = "~4.5", features = ["derive"] }
 color-print = "0.3"
-thiserror = "1"
+thiserror = "2"
 elf = "0.7"
 
 [dev-dependencies]
@@ -28,5 +32,5 @@ tempfile = "3"
 assets = [
     { source = "target/release/cargo-generate-rpm", dest = "/usr/bin/cargo-generate-rpm", mode = "0755" },
     { source = "LICENSE", dest = "/usr/share/doc/cargo-generate-rpm/LICENSE", doc = true, mode = "0644" },
-    { source = "README.md", dest = "/usr/share/doc/cargo-generate-rpm/README.md", doc = true, mode = "0644" }
+    { source = "README.md", dest = "/usr/share/doc/cargo-generate-rpm/README.md", doc = true, mode = "0644" },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["rpm", "package", "cargo", "subcommand"]
 repository = "https://github.com/cat-in-136/cargo-generate-rpm"
 version = "0.16.1"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 glob = "0.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ pub struct Cli {
     /// modification time of included files and package build time.
     ///
     /// This value can also be provided using the SOURCE_DATE_EPOCH
-    /// enviroment variable.
+    /// environment variable.
     #[arg(long)]
     pub source_date: Option<u32>,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ impl<E: StdError + Display> Display for FileAnnotatedError<E> {
 
 #[derive(thiserror::Error, Debug)]
 pub enum AutoReqError {
-    #[error("Failed to execute `{}`: {1}", .0.clone().into_string().unwrap_or_default())]
+    #[error("Failed to execute `{file}`: {1}", file = .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
     #[error(transparent)]
     Io(#[from] IoError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     CargoToml(#[from] CargoTomlError),
     #[error(transparent)]
     Config(#[from] ConfigError),
-    #[error("Invalid value of enviroment variable {0}: {1}")]
+    #[error("Invalid value of environment variable {0}: {1}")]
     #[allow(clippy::enum_variant_names)] // Allow bad terminology for compatibility
     EnvError(&'static str, String),
     #[error(transparent)]


### PR DESCRIPTION
This pull request selectively cherry-picks only the following changes from pull request #133. In addition, bump rust edition to 2024.

> Dependency updates and improvements:
> 
> * [`Cargo.toml`](https://github.com/cat-in-136/cargo-generate-rpm/pull/133/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R30): Updated the `rpm` crate to version 0.17 and added several compression features. Updated versions for `cargo_toml`, `clap`, and `thiserror` crates.
> 
> Minor fixes:
> 
> * [`Cargo.toml`](https://github.com/cat-in-136/cargo-generate-rpm/pull/133/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R9): Reformatted the `categories` and `assets` sections for better readability. [[1]](https://github.com/cat-in-136/cargo-generate-rpm/pull/133/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R9) [[2]](https://github.com/cat-in-136/cargo-generate-rpm/pull/133/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L31-R40)
> 
> * [`src/cli.rs`](https://github.com/cat-in-136/cargo-generate-rpm/pull/133/files#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL72-R72): Corrected a typo in the documentation comment for the `source_date` field.

