### PR TITLE
Add option to supply PGP signing key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rpm = { version = "0.17", default-features = false, features = [
     "gzip-compression",
     "xz-compression",
     "bzip2-compression",
+    "signature-pgp",
 ] }
 toml = "0.9"
 cargo_toml = "0.22.3"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Upon run `cargo generate-rpm` on your cargo project, a binary RPM package file w
 in `target/generate-rpm/XXX.rpm`.
 You can change the RPM package file location using `-o` option.
 
+You can sign the packaged RPM with a PGP key by providing the path to a key file with the `--signing_key` CLI option.
+
 In advance, run `cargo build --release` and strip the debug symbols (`strip -s target/release/XXX`), because these are not
 run upon `cargo generate-rpm` as of now.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{
-    builder::{PathBufValueParser, PossibleValuesParser, TypedValueParser, ValueParserFactory},
     Arg, ArgMatches, Command, CommandFactory, FromArgMatches, Parser, ValueEnum,
+    builder::{PathBufValueParser, PossibleValuesParser, TypedValueParser, ValueParserFactory},
 };
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
@@ -86,6 +86,10 @@ pub struct Cli {
     /// Shortcut to --metadata-overwrite=path/to/Cargo.toml#package.metadata.generate-rpm.variants.VARIANT
     #[arg(long, value_delimiter = ',')]
     pub variant: Vec<String>,
+
+    /// Path to a PGP private key file for signing the built RPM package
+    #[arg(long)]
+    pub signing_key: Option<PathBuf>,
 }
 
 impl Cli {


### PR DESCRIPTION
Adds a CLI option to sign the packaged RPM with a provided key
Adds the `signature-pgp` feature to the `rpm` dependency
Closes #139 