### PR TITLE
Fix config file "noreplace" when scriptlets are defined

### DIFF
--- a/src/config/file_info.rs
+++ b/src/config/file_info.rs
@@ -65,7 +65,7 @@ impl FileInfo<'_, '_, '_, '_, '_> {
             };
             let (config, config_noreplace, _config_missingok) = match table.get("config") {
                 Some(Value::Boolean(v)) => (*v, false, false),
-                Some(Value::String(v)) if v.eq("noreplace") => (false, true, false),
+                Some(Value::String(v)) if v.eq("noreplace") => (true, true, false),
                 //Some(Value::String(v)) if v.eq("missingok") => (false, false, true),
                 None => (false, false, false),
                 _ => {


### PR DESCRIPTION
The `config = "noreplace"` setting in `assets` worked fine if there were no `pre_*`, `post_*`, etc. scriptlets also defined.  However, if scriptlets were defined (either in `Cargo.toml` or an overwrite file), a config file marked "noreplace" would still get replaced when updating the RPM.  Inspection of the RPMs revealed that while the "noreplace" flag was set on config files, the "config" flag was not.  This change explicitly sets the "config" flag in addition to the "config_noreplace" flag.  With both flags set, scriptlets can be defined but the `config = "noreplace"` directive will still be honored.

I don't fully understand why "noreplace" was working without the "config" flag set, so long as there were no scriptlets.  And I don't know why setting the "config" flag resolves the issue...  It must be some behavior down in `rpm-rs`.  However, setting both flags appears necessary to get correct behavior when scriptlets are defined.