### PR TITLE
[CI] Disable payload compression on debug build in test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run binary for test purpose
       shell: bash -xe {0}
       run: |
-        cargo run --profile dev -- --profile dev
+        cargo run --profile dev -- --profile dev --payload-compress none
         test -f target/generate-rpm/cargo-generate-rpm-*.rpm
         rm -f target/generate-rpm/cargo-generate-rpm-*.rpm
         cargo run --release -- generate-rpm


### PR DESCRIPTION
The test command now includes `--payload-compress none` to reduce CI duration time

---