### PR TITLE
Enhance autoreq UTF-8 error message

### DIFF
--- a/src/auto_req/builtin.rs
+++ b/src/auto_req/builtin.rs
@@ -138,7 +138,8 @@ fn find_require_of_shebang(path: &Path) -> Result<Option<String>, AutoReqError> 
         let shebang_size = read.read(&mut shebang)?;
         if shebang_size == 2 || shebang == [b'#', b'!'] {
             let mut line = String::new();
-            read.read_line(&mut line)?;
+            read.read_line(&mut line)
+                .map_err(|e| AutoReqError::WrongShebangError(path.to_path_buf(), e))?;
             line.trim()
                 .split(|c: char| !c.is_ascii() || c.is_whitespace())
                 .next()
@@ -164,6 +165,26 @@ fn test_find_require_of_shebang() {
         find_require_of_shebang(Path::new(file!())),
         Ok(None)
     ));
+}
+
+#[test]
+fn test_find_require_of_shebang_non_utf8_executable() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+
+    let mut temp_file = tempfile::NamedTempFile::new()?;
+    let temp_path = temp_file.path().to_path_buf();
+
+    // Write a shebang followed by an invalid UTF-8 byte (0xFF).
+    // This will cause `read_line` to fail with InvalidData.
+    temp_file.write_all(&[b'#', b'!', 0xFF])?;
+    temp_file.flush()?;
+
+    assert!(matches!(find_require_of_shebang(&temp_path),
+            Err(AutoReqError::WrongShebangError(p, e))
+            if p == temp_path && e.kind() == std::io::ErrorKind::InvalidData
+    ));
+
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/auto_req/builtin.rs
+++ b/src/auto_req/builtin.rs
@@ -74,7 +74,7 @@ fn find_requires_by_ldd(
         .stdout
         .unwrap()
         .read_to_string(&mut s)
-        .map_err(|e| AutoReqError::ProcessError(OsString::from("ldd"), e))?;
+        .map_err(|e| AutoReqError::LddOutputReadError(path.to_path_buf(), e))?;
 
     let unversioned_libraries = s
         .split('\n')

--- a/src/auto_req/script.rs
+++ b/src/auto_req/script.rs
@@ -34,7 +34,7 @@ pub(super) fn find_requires<P: AsRef<Path>, S: AsRef<OsStr>>(
             Ok(content) if content == "" => (), // ignore empty line
             Ok(content) => requires.push(content),
             Err(e) => {
-                return Err(AutoReqError::ProcessError(
+                return Err(AutoReqError::ProcessOutputReadError(
                     script_path.as_ref().to_os_string(),
                     e,
                 ));

--- a/src/auto_req/script.rs
+++ b/src/auto_req/script.rs
@@ -31,7 +31,7 @@ pub(super) fn find_requires<P: AsRef<Path>, S: AsRef<OsStr>>(
 
     for line in reader.lines() {
         match line {
-            Ok(content) if content == "" => (), // ignore empty line
+            Ok(content) if content.is_empty() => (), // ignore empty line
             Ok(content) => requires.push(content),
             Err(e) => {
                 return Err(AutoReqError::ProcessOutputReadError(

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,10 @@ pub enum AutoReqError {
     #[cfg(not(unix))]
     #[error("Failed to read shebang line for file `{path}`: {1}", path = .0.display())]
     WrongShebangError(PathBuf, #[source] IoError),
+    #[error("Failed to read output stream from command `ldd` while processing file `{path}`: {1}", path = .0.display())]
+    LddOutputReadError(PathBuf, #[source] IoError),
+    #[error("Failed to read output stream from process `{file}`: {1}", file = .0.clone().into_string().unwrap_or_default())]
+    ProcessOutputReadError(OsString, #[source] IoError),
     #[error(transparent)]
     Io(#[from] IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,8 @@ impl<E: StdError + Display> Display for FileAnnotatedError<E> {
 pub enum AutoReqError {
     #[error("Failed to execute `{file}`: {1}", file = .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
+    #[error("Failed to read shebang line for file `{path}`. The file may be a non-text or binary file incorrectly marked as executable: {1}", path = .0.display())]
+    WrongShebangError(PathBuf, #[source] IoError),
     #[error(transparent)]
     Io(#[from] IoError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,11 @@ impl<E: StdError + Display> Display for FileAnnotatedError<E> {
 pub enum AutoReqError {
     #[error("Failed to execute `{file}`: {1}", file = .0.clone().into_string().unwrap_or_default())]
     ProcessError(OsString, #[source] IoError),
+    #[cfg(unix)]
     #[error("Failed to read shebang line for file `{path}`. The file may be a non-text or binary file incorrectly marked as executable: {1}", path = .0.display())]
+    WrongShebangError(PathBuf, #[source] IoError),
+    #[cfg(not(unix))]
+    #[error("Failed to read shebang line for file `{path}`: {1}", path = .0.display())]
     WrongShebangError(PathBuf, #[source] IoError),
     #[error(transparent)]
     Io(#[from] IoError),


### PR DESCRIPTION
This pull request enhances the error messages related to UTF-8 issues in  command output.

Key changes include:
*   Simplifying empty line checks in .
*   Adding dedicated error variants for  command output errors, such as UTF-8 coding issues.
*   Adding platform-specific  messages.
*   Introducing  for non-UTF-8 shebang lines.

This is same as the original PR #149, which was wrongly closed.